### PR TITLE
Email import plugin

### DIFF
--- a/plugins/example/import/email-import/README.md
+++ b/plugins/example/import/email-import/README.md
@@ -1,0 +1,84 @@
+# Email Importer Plugin
+
+**Status:** Prototype plugin for importing emails into OMI.  
+**Bounty:** Implements issue #1895 (Import data from email) by providing a self‑contained Python/Flask integration plugin.  
+
+## Overview
+
+This plugin demonstrates how to fetch email messages from an IMAP mailbox, extract actionable “memories” from each message and submit them to the OMI API.  
+It follows the structure of the existing `manual‑import` plugin but adapts it to work with emails instead of arbitrary text.
+
+### Features
+
+* Connects to any standard IMAP server (e.g. Gmail, Outlook, ProtonMail).  
+* Fetches the most recent N messages from the inbox and displays their subject and plain‑text body.  
+* Allows the user to select which messages to import.  
+* Extracts concise “memory” summaries from each selected message using a simple rule‑based approach (e.g. looks for lines beginning with `TODO`, `Action:`, bullet points or numbered lists).  
+* Submits each extracted memory to the OMI API as a fact (requires an OMI App ID and private key).  
+* Works offline with local `.eml` files for testing purposes when an IMAP connection is not available.
+
+## Quick Start
+
+1. **Install dependencies**
+
+   ```bash
+   # Within the email‑import directory
+   pip install -r requirements.txt
+   ```
+
+2. **Prepare environment variables**
+
+   Create a `.env` file in this directory or set the variables in your shell:
+
+   ```bash
+   # IMAP connection details
+   EMAIL_HOST=imap.example.com
+   EMAIL_PORT=993
+   EMAIL_USER=your_email@example.com
+   EMAIL_PASS=your_password
+
+   # Optional: fallback to a local .eml file for testing
+   SAMPLE_EMAIL_FILE=sample.eml
+
+   # OMI API credentials
+   APP_ID=YOUR_APP_ID
+   API_KEY=YOUR_API_KEY
+   # Base URL for the OMI API (defaults to https://api.omi.me)
+   OMI_API_URL=https://api.omi.me
+   ```
+
+3. **Run the server**
+
+   ```bash
+   python app.py
+   ```
+
+   The plugin will start a Flask server on port 5002 by default.  
+   Open your browser to `http://localhost:5002/?uid=YOUR_USER_ID` to access the UI.
+
+4. **Fetch emails and submit memories**
+
+   * Enter your IMAP credentials, number of messages to fetch and click **Fetch Emails**.  
+   * Select one or more messages to import and click **Extract & Submit**.  
+   * The plugin will display extracted memories and attempt to post them to the OMI API.  
+   * If OMI credentials are not provided the memories will still be displayed but not submitted.
+
+## How it Works
+
+* The backend (`app.py`) exposes three endpoints:
+
+  * `GET /` – serves the `index.html` UI.
+  * `POST /fetch-emails` – logs into the IMAP server, fetches the requested number of messages, parses the subject and body (preferring plain‑text), and returns them as JSON.  If `SAMPLE_EMAIL_FILE` is set the message is read from that file instead of connecting to a remote server (useful for offline testing).
+  * `POST /submit-memories` – takes a list of raw email bodies and a user ID, extracts memories with a rule‑based parser and, if OMI credentials are configured, posts each memory to the OMI API.  It returns a success flag and per‑memory status codes.
+
+* The frontend (`index.html`) is a lightweight single‑page application that collects IMAP credentials from the user, calls the backend to fetch messages, allows selection of messages and then submits the selected contents for extraction and upload.
+
+* **Memory extraction** uses a simple heuristic: lines beginning with common action prefixes (`TODO`, `Action:`, `•`, `-`, numbers) are treated as separate memories.  If none are found the entire email body (truncated to 500 characters) is used as a single memory.  This rule‑based approach avoids the need for OpenAI API keys but can be extended with AI in the future.
+
+## Limitations & Next Steps
+
+* OAuth–based providers (like Gmail) may require an application password or OAuth token.  To keep this example simple, the plugin uses plain IMAP authentication.  Advanced implementations should integrate OAuth flows and token refresh.
+* HTML‑only emails are converted to plain text using Python’s `email` module; some formatting may be lost.  Consider using a library like **beautifulsoup4** for more robust HTML parsing if needed.
+* At present there is no paging or stateful sync – each fetch loads the N latest messages.  A production‑ready plugin should remember which messages have already been imported and only process new ones.
+
+This plugin is provided as a starting point for the email import bounty.  Feel free to extend and refine it to meet your personal needs or to contribute back improvements to the OMI ecosystem!

--- a/plugins/example/import/email-import/app.py
+++ b/plugins/example/import/email-import/app.py
@@ -1,0 +1,338 @@
+"""
+Email Importer Plugin for OMI
+
+This Flask application provides a simple interface for fetching email
+messages from an IMAP mailbox, extracting actionable memories and
+submitting them to the OMI API.  It is inspired by the existing
+manual‑import plugin but tailored specifically for email integration.
+
+Endpoints:
+
+* `GET /` – Serves the frontend interface (index.html).
+* `POST /fetch-emails` – Connects to an IMAP server and returns the
+  most recent messages.  If the `SAMPLE_EMAIL_FILE` environment
+  variable is set, the server reads messages from a local .eml file
+  instead of connecting to IMAP (useful for offline testing).
+* `POST /submit-memories` – Takes raw email bodies and a user ID,
+  extracts concise memories from each email and optionally submits
+  them to the OMI API.  Responses include per‑memory status codes.
+
+Environment variables read by this module:
+
+* `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_USER`, `EMAIL_PASS` – Default
+  IMAP credentials.  These may be overridden in the POST payload.
+* `SAMPLE_EMAIL_FILE` – Path to a `.eml` file to use when no IMAP
+  connection is configured (for testing without network access).
+* `APP_ID`, `API_KEY` – OMI integration credentials.  If either is
+  missing the plugin will still extract memories but will not send
+  them to the API.
+* `OMI_API_URL` – Base URL for the OMI API (defaults to
+  `https://api.omi.me`).
+"""
+
+import os
+import re
+import time
+import json
+import imaplib
+import email
+from email.policy import default as default_policy
+from flask import Flask, request, jsonify, send_from_directory
+import requests
+from dotenv import load_dotenv
+
+# Load environment variables from .env if present
+load_dotenv()
+
+app = Flask(__name__)
+
+# Default configuration from environment
+DEFAULT_EMAIL_HOST = os.getenv('EMAIL_HOST')
+DEFAULT_EMAIL_PORT = int(os.getenv('EMAIL_PORT', '993'))
+DEFAULT_EMAIL_USER = os.getenv('EMAIL_USER')
+DEFAULT_EMAIL_PASS = os.getenv('EMAIL_PASS')
+SAMPLE_EMAIL_FILE = os.getenv('SAMPLE_EMAIL_FILE')
+
+APP_ID = os.getenv('APP_ID')
+API_KEY = os.getenv('API_KEY')
+OMI_API_URL = os.getenv('OMI_API_URL', 'https://api.omi.me')
+
+# Maximum length for a single memory (mirrors manual‑import)
+MAX_MEMORY_LENGTH = 500
+
+
+@app.route('/')
+def index():
+    """Serve the frontend interface."""
+    return send_from_directory('.', 'index.html')
+
+
+@app.route('/fetch-emails', methods=['POST'])
+def fetch_emails():
+    """
+    Fetch the latest email messages from an IMAP mailbox or a local .eml file.
+
+    The request JSON may contain the following keys:
+
+    * `host` – IMAP server hostname (falls back to `EMAIL_HOST`).
+    * `port` – IMAP server port (defaults to 993 for SSL).
+    * `username` – IMAP login username (falls back to `EMAIL_USER`).
+    * `password` – IMAP login password (falls back to `EMAIL_PASS`).
+    * `count` – Number of messages to fetch (defaults to 5).  Maximum 20.
+
+    Returns a JSON array of objects with `subject` and `body` keys.
+    """
+    try:
+        data = request.get_json() or {}
+
+        host = data.get('host') or DEFAULT_EMAIL_HOST
+        port = int(data.get('port') or DEFAULT_EMAIL_PORT)
+        username = data.get('username') or DEFAULT_EMAIL_USER
+        password = data.get('password') or DEFAULT_EMAIL_PASS
+        count = int(data.get('count', 5))
+        if count < 1:
+            count = 1
+        if count > 20:
+            count = 20  # limit to avoid huge responses
+
+        messages = []
+
+        # Use local sample file if provided and no host/user specified
+        if SAMPLE_EMAIL_FILE and not (host and username and password):
+            if not os.path.isfile(SAMPLE_EMAIL_FILE):
+                return jsonify({"error": f"Sample file {SAMPLE_EMAIL_FILE} not found"}), 400
+            with open(SAMPLE_EMAIL_FILE, 'rb') as f:
+                raw = f.read()
+            msg = email.message_from_bytes(raw, policy=default_policy)
+            messages.append({
+                'subject': msg.get('Subject', '(No subject)'),
+                'body': extract_text_from_email(msg)
+            })
+            return jsonify({"messages": messages, "sample": True})
+
+        # Validate IMAP credentials
+        if not all([host, username, password]):
+            return jsonify({"error": "Missing IMAP credentials and no sample file specified"}), 400
+
+        # Connect and fetch messages
+        try:
+            imap = imaplib.IMAP4_SSL(host, port) if port == 993 else imaplib.IMAP4(host, port)
+            imap.login(username, password)
+            imap.select('INBOX')
+
+            # Search for all messages, then fetch the latest ones
+            typ, data_ids = imap.search(None, 'ALL')
+            if typ != 'OK':
+                raise Exception('Failed to search mailbox')
+            ids = data_ids[0].split()
+            # Get the last `count` message IDs
+            ids = ids[-count:]
+
+            for msg_id in reversed(ids):  # reverse to get newest first
+                typ, msg_data = imap.fetch(msg_id, '(RFC822)')
+                if typ != 'OK':
+                    continue
+                raw = msg_data[0][1]
+                msg = email.message_from_bytes(raw, policy=default_policy)
+                messages.append({
+                    'subject': msg.get('Subject', '(No subject)'),
+                    'body': extract_text_from_email(msg)
+                })
+            imap.close()
+            imap.logout()
+        except Exception as e:
+            return jsonify({"error": f"IMAP error: {str(e)}"}), 500
+
+        return jsonify({"messages": messages})
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+def extract_text_from_email(msg):
+    """
+    Extract the plain‑text body from an `email.message.EmailMessage`.  If no
+    text part is found, attempts to extract from HTML and strip tags.  As
+    a fallback returns an empty string.
+    """
+    # Prefer text/plain parts
+    if msg.is_multipart():
+        for part in msg.walk():
+            content_type = part.get_content_type()
+            content_disposition = str(part.get('Content-Disposition'))
+            if content_type == 'text/plain' and 'attachment' not in content_disposition:
+                try:
+                    return part.get_content().strip()
+                except Exception:
+                    return part.get_payload(decode=True).decode(part.get_content_charset('utf-8'), errors='replace').strip()
+        # If no plain text, try HTML
+        for part in msg.walk():
+            if part.get_content_type() == 'text/html':
+                html_content = part.get_content()
+                return strip_html_tags(html_content).strip()
+    else:
+        if msg.get_content_type() == 'text/plain':
+            return msg.get_content().strip()
+        if msg.get_content_type() == 'text/html':
+            return strip_html_tags(msg.get_content()).strip()
+    return ''
+
+
+def strip_html_tags(html):
+    """
+    Very simple HTML tag stripper.  For more complex email bodies consider
+    using beautifulsoup4, but to avoid external dependencies we keep
+    this implementation minimal.
+    """
+    # Remove script and style content
+    html = re.sub(r'<(script|style).*?>.*?</\1>', '', html, flags=re.DOTALL | re.IGNORECASE)
+    # Remove all remaining tags
+    text = re.sub(r'<[^>]+>', '', html)
+    # Replace HTML entities
+    text = (text.replace('&nbsp;', ' ').replace('&amp;', '&')
+                .replace('&lt;', '<').replace('&gt;', '>'))
+    # Collapse whitespace
+    return re.sub(r'\s+', ' ', text)
+
+
+def extract_memories_from_text(body):
+    """
+    Extract a list of memory strings from a raw email body.  The
+    extraction is rule based:
+
+    * Lines that begin with typical action prefixes (e.g. `TODO`, `Action`,
+      bullet points like `-`, `•`, `*` or numbered lists) become separate
+      memories.
+    * If no such lines exist, the entire body (up to 500 characters) is
+      returned as a single memory.
+    * Each memory is truncated at `MAX_MEMORY_LENGTH` characters.
+    """
+    memories = []
+    lines = body.splitlines()
+    action_pattern = re.compile(r'^\s*(?:\d+[\).]|[-*\u2022]|todo|action[:\-])', re.IGNORECASE)
+
+    for line in lines:
+        cleaned = line.strip()
+        if not cleaned:
+            continue
+        if action_pattern.match(cleaned):
+            # Strip the prefix and any colon/parentheses
+            text = re.sub(r'^\s*(?:\d+[\).]|[-*\u2022]|todo|action[:\-])\s*', '', cleaned, flags=re.IGNORECASE)
+            if text:
+                # Remove lingering TODO or Action prefixes
+                text = re.sub(r'^\s*(?:todo|action)[:\-]\s*', '', text, flags=re.IGNORECASE)
+                memories.append(text[:MAX_MEMORY_LENGTH])
+
+    # Fallback: use the whole body if no memories extracted
+    if not memories and body:
+        truncated = body.strip()[:MAX_MEMORY_LENGTH]
+        memories.append(truncated)
+
+    return memories[:5]  # limit to at most 5 memories per email
+
+
+@app.route('/submit-memories', methods=['POST'])
+def submit_memories():
+    """
+    Extract memories from raw email bodies and optionally submit them
+    to the OMI API.  The request JSON must include:
+
+    * `uid` – User ID to assign the memories to.
+    * `messages` – List of strings (email bodies) to process.
+    * `use_api` – Optional boolean; if false, skip sending to OMI even
+      when API credentials are present.
+
+    Returns JSON indicating success and a list of per‑memory results.
+    """
+    try:
+        data = request.get_json() or {}
+        uid = data.get('uid')
+        raw_messages = data.get('messages') or []
+        use_api = data.get('use_api', True)
+
+        if not uid:
+            return jsonify({"error": "Missing 'uid' in request"}), 400
+        if not raw_messages:
+            return jsonify({"error": "No messages provided"}), 400
+
+        all_memories = []
+        for body in raw_messages:
+            memories = extract_memories_from_text(body)
+            all_memories.extend(memories)
+
+        # Prepare results container
+        results = []
+        success_count = 0
+        error_count = 0
+
+        # Determine if we can call the API
+        api_available = APP_ID and API_KEY and use_api
+
+        for memory in all_memories:
+            # Ensure memory not empty and within max length
+            mem = memory.strip()[:MAX_MEMORY_LENGTH]
+            if not mem:
+                continue
+
+            result = {
+                'memory': mem
+            }
+
+            if api_available:
+                # Construct the endpoint
+                endpoint = f"{OMI_API_URL}/v2/integrations/{APP_ID}/user/facts?uid={uid}"
+                headers = {
+                    'Authorization': f'Bearer {API_KEY}',
+                    'Content-Type': 'application/json'
+                }
+                payload = {
+                    'text': mem,
+                    'text_source': 'email',
+                    'text_source_spec': 'import'
+                }
+                try:
+                    resp = requests.post(endpoint, headers=headers, data=json.dumps(payload))
+                    result['status_code'] = resp.status_code
+                    result['success'] = resp.status_code == 200
+                    if resp.status_code == 200:
+                        success_count += 1
+                    else:
+                        error_count += 1
+                        result['error'] = resp.text
+                except Exception as e:
+                    result['status_code'] = None
+                    result['success'] = False
+                    result['error'] = str(e)
+                    error_count += 1
+            else:
+                # API not available: simulate success
+                result['status_code'] = None
+                result['success'] = False
+                result['error'] = 'OMI API credentials not configured or API disabled'
+                error_count += 1
+
+            results.append(result)
+
+        all_success = (error_count == 0)
+        return jsonify({
+            'success': all_success,
+            'total_memories': len(all_memories),
+            'success_count': success_count,
+            'error_count': error_count,
+            'results': results,
+            'api_used': api_available
+        })
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+if __name__ == '__main__':
+    port = int(os.getenv('PORT', '5002'))
+    print("Starting Email Importer server...")
+    print(f" Listening on http://localhost:{port}")
+    if APP_ID and API_KEY:
+        print(f" OMI API configured: App ID {APP_ID}")
+    else:
+        print(" Warning: OMI API credentials not set – memories will not be submitted")
+    app.run(host='0.0.0.0', port=port, debug=True)

--- a/plugins/example/import/email-import/index.html
+++ b/plugins/example/import/email-import/index.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Email Importer</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+            margin: 0;
+            padding: 20px;
+            max-width: 700px;
+            margin: 0 auto;
+            color: #333;
+        }
+        h1 {
+            font-size: 1.8rem;
+            color: #2c3e50;
+            margin-bottom: 1rem;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: 600;
+        }
+        input[type="text"], input[type="password"], input[type="number"] {
+            width: 100%;
+            padding: 8px;
+            margin-bottom: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+        button {
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            padding: 12px 20px;
+            font-size: 16px;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: background-color 0.3s;
+            margin-right: 10px;
+        }
+        button:hover {
+            background-color: #45a049;
+        }
+        .message-list {
+            margin-top: 20px;
+        }
+        .message-item {
+            border-left: 4px solid #4CAF50;
+            background-color: #f8f9fa;
+            padding: 10px;
+            margin-bottom: 10px;
+            border-radius: 4px;
+        }
+        .error {
+            color: #a94442;
+            margin-top: 10px;
+        }
+        .success {
+            color: #3c763d;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Email Importer</h1>
+    <p>Fetch recent emails from your IMAP inbox and import actionable memories into OMI.</p>
+
+    <div id="uid-warning" style="display: none; background-color: #fff3cd; color: #856404; padding: 10px; border-left: 4px solid #ffeeba; margin-bottom: 10px;">
+        <strong>No User ID detected!</strong> Add <code>?uid=YOUR_USER_ID</code> to the URL.
+    </div>
+
+    <form id="fetch-form">
+        <label for="host">IMAP Host</label>
+        <input type="text" id="host" placeholder="imap.example.com" autocomplete="username">
+
+        <label for="port">Port</label>
+        <input type="number" id="port" value="993">
+
+        <label for="username">Email Address</label>
+        <input type="text" id="username" placeholder="you@example.com">
+
+        <label for="password">Password</label>
+        <input type="password" id="password" placeholder="Password">
+
+        <label for="count">Number of messages</label>
+        <input type="number" id="count" value="5" min="1" max="20">
+
+        <button type="button" id="fetch-btn">Fetch Emails</button>
+    </form>
+
+    <div id="fetch-error" class="error"></div>
+
+    <div id="messages" class="message-list"></div>
+
+    <button type="button" id="submit-btn" style="display: none;">Extract & Submit</button>
+    <div id="submit-status" class="success"></div>
+
+    <script>
+        // Utility: get uid from URL parameters
+        function getUid() {
+            const params = new URLSearchParams(window.location.search);
+            return params.get('uid');
+        }
+        const uid = getUid();
+        const uidWarning = document.getElementById('uid-warning');
+        if (!uid) {
+            uidWarning.style.display = 'block';
+        }
+
+        const fetchBtn = document.getElementById('fetch-btn');
+        const submitBtn = document.getElementById('submit-btn');
+        const fetchError = document.getElementById('fetch-error');
+        const submitStatus = document.getElementById('submit-status');
+        const messagesDiv = document.getElementById('messages');
+
+        let fetchedMessages = [];
+
+        fetchBtn.addEventListener('click', async () => {
+            fetchError.textContent = '';
+            submitStatus.textContent = '';
+            messagesDiv.innerHTML = '';
+            submitBtn.style.display = 'none';
+            fetchedMessages = [];
+
+            // Collect form data
+            const host = document.getElementById('host').value.trim();
+            const port = parseInt(document.getElementById('port').value) || 993;
+            const username = document.getElementById('username').value.trim();
+            const password = document.getElementById('password').value;
+            const count = parseInt(document.getElementById('count').value) || 5;
+
+            try {
+                const response = await fetch('/fetch-emails', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ host, port, username, password, count })
+                });
+                const result = await response.json();
+                if (!response.ok) {
+                    fetchError.textContent = result.error || 'Unknown error';
+                    return;
+                }
+                fetchedMessages = result.messages || [];
+                if (fetchedMessages.length === 0) {
+                    fetchError.textContent = 'No messages found.';
+                    return;
+                }
+                // Render messages with checkboxes
+                fetchedMessages.forEach((msg, index) => {
+                    const container = document.createElement('div');
+                    container.className = 'message-item';
+                    const cb = document.createElement('input');
+                    cb.type = 'checkbox';
+                    cb.id = 'msg_' + index;
+                    cb.dataset.index = index;
+                    cb.checked = true;
+                    const label = document.createElement('label');
+                    label.htmlFor = 'msg_' + index;
+                    label.style.fontWeight = 'bold';
+                    label.textContent = msg.subject;
+                    const body = document.createElement('pre');
+                    body.textContent = msg.body.substring(0, 500) + (msg.body.length > 500 ? '…' : '');
+                    container.appendChild(cb);
+                    container.appendChild(label);
+                    container.appendChild(body);
+                    messagesDiv.appendChild(container);
+                });
+                submitBtn.style.display = 'inline-block';
+            } catch (err) {
+                fetchError.textContent = err.message;
+            }
+        });
+
+        submitBtn.addEventListener('click', async () => {
+            if (!uid) {
+                alert('User ID missing. Add ?uid=YOUR_USER_ID to the URL.');
+                return;
+            }
+            submitStatus.textContent = '';
+            const selected = [];
+            const checkboxes = messagesDiv.querySelectorAll('input[type="checkbox"]');
+            checkboxes.forEach(cb => {
+                if (cb.checked) {
+                    const idx = parseInt(cb.dataset.index);
+                    if (fetchedMessages[idx]) {
+                        selected.push(fetchedMessages[idx].body);
+                    }
+                }
+            });
+            if (selected.length === 0) {
+                submitStatus.textContent = 'No messages selected.';
+                return;
+            }
+            submitStatus.textContent = 'Submitting…';
+            try {
+                const response = await fetch('/submit-memories', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ uid, messages: selected })
+                });
+                const result = await response.json();
+                if (!response.ok) {
+                    submitStatus.textContent = 'Error: ' + (result.error || 'Unknown error');
+                    return;
+                }
+                if (result.success) {
+                    submitStatus.textContent = `Successfully processed ${result.total_memories} memories.`;
+                } else {
+                    submitStatus.textContent = `Processed ${result.total_memories} memories with ${result.error_count} errors.`;
+                }
+            } catch (err) {
+                submitStatus.textContent = err.message;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/plugins/example/import/email-import/requirements.txt
+++ b/plugins/example/import/email-import/requirements.txt
@@ -1,0 +1,4 @@
+flask
+python-dotenv
+requests
+email-parser==0.1.5  # lightweight email parsing helper

--- a/plugins/example/import/email-import/sample.eml
+++ b/plugins/example/import/email-import/sample.eml
@@ -1,0 +1,20 @@
+Return-Path: <test@example.com>
+Delivered-To: you@example.com
+Subject: Meeting follow-up and TODOs
+From: Test Sender <test@example.com>
+To: you@example.com
+Date: Thu, 25 Aug 2025 10:00:00 -0400
+Content-Type: text/plain; charset="UTF-8"
+
+Hi there,
+
+Thanks for meeting today. Here are the action items:
+
+1. Review the project proposal and provide feedback.
+2. TODO: Finalize the budget by Friday.
+3. Prepare slides for the client presentation.
+
+Please let me know if you have any questions.
+
+Best regards,
+Test Sender


### PR DESCRIPTION
This PR adds an email import plugin under `plugins/example/import/email-import`.

The plugin provides a Flask web interface to connect to an IMAP mailbox (or use a local .eml file), extract actionable "memories" from messages via rule-based heuristics, and submit them to the OMI API. It includes:
- `README.md` with setup and usage details
- `app.py` Flask backend to fetch emails, extract memories, and post to OMI
- `index.html` UI for entering IMAP credentials and selecting messages
- `requirements.txt` listing required Python packages
- `sample.eml` example email for testing

The memory extraction heuristics look for lines starting with bullets, numbers, TODO, or Action prefixes, cleaning up the text and limiting to 500 characters.

This addresses issue #1895 (Import data from email).