### PR TITLE
Add Device Finder BLE service for Omi firmware

### DIFF
--- a/omi/firmware/omi/CMakeLists.txt
+++ b/omi/firmware/omi/CMakeLists.txt
@@ -12,11 +12,13 @@ file(GLOB app_sources
     src/haptic.c
     src/sd_card.c
     src/spi_flash.c
+        src/device_finder.c
     src/settings.c
 )
 file(GLOB dk2_sources
+    /
     src/lib/dk2/config.h
-    src/lib/dk2/codec.c
+    slib/dk2/codec.c
     src/lib/dk2/transport.c
     src/lib/dk2/button.c
 )

--- a/omi/firmware/omi/src/device_finder.c
+++ b/omi/firmware/omi/src/device_finder.c
@@ -1,0 +1,106 @@
+#include <zephyr/kernel.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/logging/log.h>
+#include "lib/dk2/device_finder.h"
+#include "lib/dk2/led.h"
+#include "lib/dk2/haptic.h"
+
+LOG_MODULE_REGISTER(device_finder, CONFIG_LOG_DEFAULT_LEVEL);
+
+static bool device_finder_active;
+static struct k_work_delayable device_finder_work;
+
+/* UUID definitions */
+static struct bt_uuid_128 df_service_uuid = BT_UUID_INIT_128(
+    BT_UUID_128_ENCODE(0x19B10030, 0xE8F2, 0x537E, 0x4F6C, 0xD104768A1214));
+
+static struct bt_uuid_128 df_char_uuid = BT_UUID_INIT_128(
+    BT_UUID_128_ENCODE(0x19B10031, 0xE8F2, 0x537E, 0x4F6C, 0xD104768A1214));
+
+static ssize_t df_write_handler(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+                                const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
+{
+    if (len < 1) {
+        return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+    }
+    uint8_t value = ((const uint8_t *)buf)[0];
+    if (value) {
+        device_finder_start();
+    } else {
+        device_finder_stop();
+    }
+    return len;
+}
+
+static struct bt_gatt_attr df_attrs[] = {
+    BT_GATT_PRIMARY_SERVICE(&df_service_uuid),
+    BT_GATT_CHARACTERISTIC(&df_char_uuid.uuid, BT_GATT_CHRC_WRITE,
+                           BT_GATT_PERM_WRITE, NULL, df_write_handler, NULL),
+};
+
+static struct bt_gatt_service df_service = BT_GATT_SERVICE(df_attrs);
+
+static void device_finder_work_handler(struct k_work *work)
+{
+    static bool state = false;
+
+    if (!device_finder_active) {
+        set_led_red(false);
+        set_led_green(false);
+        set_led_blue(false);
+        haptic_off();
+        return;
+    }
+
+    if (state) {
+        set_led_red(false);
+        set_led_green(false);
+        set_led_blue(false);
+        haptic_off();
+    } else {
+        set_led_red(true);
+        set_led_green(true);
+        set_led_blue(true);
+        play_haptic_milli(200);
+    }
+
+    state = !state;
+    k_work_schedule(&device_finder_work, K_MSEC(500));
+}
+
+void device_finder_start(void)
+{
+    if (device_finder_active) {
+        return;
+    }
+    device_finder_active = true;
+    k_work_init_delayable(&device_finder_work, device_finder_work_handler);
+    k_work_schedule(&device_finder_work, K_NO_WAIT);
+    LOG_INF("Device Finder started");
+}
+
+void device_finder_stop(void)
+{
+    if (!device_finder_active) {
+        return;
+    }
+    device_finder_active = false;
+    k_work_cancel_delayable(&device_finder_work);
+    set_led_red(false);
+    set_led_green(false);
+    set_led_blue(false);
+    haptic_off();
+    LOG_INF("Device Finder stopped");
+}
+
+void register_device_finder_service(void)
+{
+    int err = bt_gatt_service_register(&df_service);
+    if (err) {
+        LOG_ERR("Device Finder service registration failed (err %d)", err);
+    } else {
+        LOG_INF("Device Finder service registered");
+    }
+}

--- a/omi/firmware/omi/src/lib/dk2/device_finder.h
+++ b/omi/firmware/omi/src/lib/dk2/device_finder.h
@@ -1,0 +1,21 @@
+#ifndef DEVICE_FINDER_H
+#define DEVICE_FINDER_H
+
+#include <zephyr/kernel.h>
+
+/**
+ * @brief Registers the Device Finder BLE service.
+ */
+void register_device_finder_service(void);
+
+/**
+ * @brief Starts the device-finder sequence.
+ */
+void device_finder_start(void);
+
+/**
+ * @brief Stops the device-finder sequence.
+ */
+void device_finder_stop(void);
+
+#endif /* DEVICE_FINDER_H */

--- a/omi/firmware/omi/src/lib/dk2/transport.c
+++ b/omi/firmware/omi/src/lib/dk2/transport.c
@@ -25,6 +25,8 @@
 #include "haptic.h"
 #include "settings.h"
 #include "features.h"
+#include "device_finder.h"
+
 #include <math.h> // For float conversion in logs
 LOG_MODULE_REGISTER(transport, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -921,9 +923,13 @@ int transport_start()
     LOG_INF("Haptic service registered via transport");
 #endif
 
-#ifdef CONFIG_OMI_ENABLE_SPEAKER
-    err = speaker_init();
-    if (err)
+
+	register_device_finder_service();
+    LOG_INF("Device Finder service registered via transport");
+	
+	#ifdef CONFIG_OMI_ENABLE_SPEAKER
+if (err)
+		
     {
         LOG_ERR("Speaker failed to start");
         return 0;


### PR DESCRIPTION
This pull request introduces a BLE Device Finder feature for the Omi CV1 firmware.

Key changes:
- Added `src/device_finder.c` implementing a custom BLE service with UUID 19B10030-E8F2-537E-4F6C-D104768A1214. The service exposes a writable characteristic that starts/stops a flashing LED + haptic pattern to help locate the device.
- Added header `src/lib/dk2/device_finder.h` declaring the service registration and start/stop functions.
- Updated `transport.c` to include `device_finder.h` and register the Device Finder service during transport startup.
- Updated `CMakeLists.txt` to add `src/device_finder.c` to the app sources so it is compiled.

Once merged, the Omi mobile app can trigger the device finder by writing 0x01 to the Device Finder characteristic and stop it with 0x00.

Please review and merge to enable this feature.