### PR TITLE
chore: add cost-safe GitHub Codespaces devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "omi-fork-dev",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22-bookworm",
+  "hostRequirements": {
+    "cpus": 2,
+    "memory": "8gb",
+    "storage": "32gb"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "ms-python.python"
+      ]
+    },
+    "codespaces": {
+      "openFiles": [
+        "README.md",
+        "AGENTS.md"
+      ]
+    }
+  },
+  "postCreateCommand": "npm install || true"
+}


### PR DESCRIPTION
## Summary
Add a baseline GitHub Codespaces devcontainer with cost-safe defaults for contributor onboarding.

## Defaults
- 2 CPU, 8 GB RAM, 32 GB storage
- GitHub CLI + Python where needed
- Light post-create bootstrap

## Why
Makes cloud dev reproducible and quick while controlling spend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a development container configuration to streamline environment setup in dev containers and Codespaces: uses a modern Node.js image with Python support, reserves minimal host resources, auto-installs recommended VS Code extensions, opens key documentation on start, and runs initial dependency installation (non-blocking on failure).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->