### PR TITLE
fix(desktop): route 'Open Chrome' Execute clicks to open(1) instead of the LLM

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -375,6 +375,78 @@ final class AgentPillsManager: ObservableObject {
         )
     }
 
+    /// Direct-action variant of `spawnForNotification`: runs a deterministic
+    /// host-side action (e.g. `open -a "Google Chrome"`) without an LLM turn,
+    /// then surfaces a terminal `.done` pill describing what happened. Shares
+    /// the same dedup window as `spawnForNotification` so a double-click can't
+    /// launch Chrome twice — and so the second click doesn't quietly fall
+    /// back to the LLM path either.
+    @discardableResult
+    func spawnDirectActionForNotification(
+        notificationId: UUID,
+        query: String,
+        model: String,
+        title: String,
+        action: ProactiveTaskExecute.DirectDesktopAction
+    ) async -> AgentPill? {
+        if recentExecuteNotificationIds.contains(notificationId) {
+            log("AgentPillsManager: ignoring duplicate Execute click for notification \(notificationId)")
+            return nil
+        }
+        recentExecuteNotificationIds.insert(notificationId)
+        let ttl = executeDedupTTL
+        DispatchQueue.main.asyncAfter(deadline: .now() + ttl) { [weak self] in
+            self?.recentExecuteNotificationIds.remove(notificationId)
+        }
+
+        let activity: String
+        do {
+            activity = try await ProactiveTaskExecute.perform(action)
+        } catch {
+            activity = "Failed: \(error.localizedDescription)"
+        }
+        return spawnCompletedDirectAction(
+            query: query,
+            model: model,
+            title: title,
+            activity: activity
+        )
+    }
+
+    /// Create a terminal pill for deterministic host-side actions that have
+    /// already run. No ChatProvider, no agent session — we just want a `.done`
+    /// pill so the user sees a record of "Opened Google Chrome." alongside
+    /// their other Execute history.
+    @discardableResult
+    func spawnCompletedDirectAction(
+        query: String,
+        model: String,
+        title: String,
+        activity: String
+    ) -> AgentPill {
+        let pill = AgentPill(query: query, model: model, isExecuteMode: true)
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedTitle.isEmpty {
+            pill.title = String(trimmedTitle.prefix(40))
+        }
+
+        if pills.count >= maxPills {
+            if let idx = pills.firstIndex(where: { isFinished($0.status) }) {
+                cleanup(pillID: pills[idx].id)
+            } else {
+                cleanup(pillID: pills[0].id)
+            }
+        }
+
+        pill.status = .done
+        pill.latestActivity = ProactiveTaskExecute.completionActivityText(from: activity)
+        pill.completedAt = Date()
+        pill.attemptCount = 1
+        pill.suggestedFollowUps = AgentPillsManager.deriveFollowUps(for: pill)
+        pills.append(pill)
+        return pill
+    }
+
     /// Spawn a new agent pill. Each pill gets its own ChatProvider so the
     /// pills truly run in parallel. Bridge boots are staggered through
     /// `bootChain` so we never race ACP startup; once a pill's bridge is

--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -377,10 +377,14 @@ final class AgentPillsManager: ObservableObject {
 
     /// Direct-action variant of `spawnForNotification`: runs a deterministic
     /// host-side action (e.g. `open -a "Google Chrome"`) without an LLM turn,
-    /// then surfaces a terminal `.done` pill describing what happened. Shares
-    /// the same dedup window as `spawnForNotification` so a double-click can't
+    /// then surfaces a terminal pill describing what happened. Shares the
+    /// same dedup window as `spawnForNotification` so a double-click can't
     /// launch Chrome twice — and so the second click doesn't quietly fall
     /// back to the LLM path either.
+    ///
+    /// On a non-zero exit from `/usr/bin/open` the pill lands as `.failed`,
+    /// not `.done`, so the UI / status snapshot don't claim success for a
+    /// launch that didn't happen.
     @discardableResult
     func spawnDirectActionForNotification(
         notificationId: UUID,
@@ -400,29 +404,38 @@ final class AgentPillsManager: ObservableObject {
         }
 
         let activity: String
+        let status: AgentPill.Status
         do {
             activity = try await ProactiveTaskExecute.perform(action)
+            status = .done
         } catch {
-            activity = "Failed: \(error.localizedDescription)"
+            let reason = error.localizedDescription
+            activity = "Failed: \(reason)"
+            status = .failed(reason)
         }
         return spawnCompletedDirectAction(
             query: query,
             model: model,
             title: title,
-            activity: activity
+            activity: activity,
+            status: status
         )
     }
 
     /// Create a terminal pill for deterministic host-side actions that have
-    /// already run. No ChatProvider, no agent session — we just want a `.done`
-    /// pill so the user sees a record of "Opened Google Chrome." alongside
-    /// their other Execute history.
+    /// already run. No ChatProvider, no agent session — we just want a
+    /// finished pill (`.done` on success, `.failed` on a non-zero exit) so
+    /// the user sees a record of what happened alongside their other Execute
+    /// history. `status` defaults to `.done` to keep the success-path call
+    /// sites short; callers that ran a process pass through the actual
+    /// outcome.
     @discardableResult
     func spawnCompletedDirectAction(
         query: String,
         model: String,
         title: String,
-        activity: String
+        activity: String,
+        status: AgentPill.Status = .done
     ) -> AgentPill {
         let pill = AgentPill(query: query, model: model, isExecuteMode: true)
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -438,7 +451,7 @@ final class AgentPillsManager: ObservableObject {
             }
         }
 
-        pill.status = .done
+        pill.status = status
         pill.latestActivity = ProactiveTaskExecute.completionActivityText(from: activity)
         pill.completedAt = Date()
         pill.attemptCount = 1

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -229,6 +229,31 @@ struct FloatingControlBarView: View {
                             context: notification.context
                         )
 
+                        // Fast path: deterministic desktop intents (open Chrome,
+                        // Safari, Finder, or a URL in a known browser). Routing
+                        // these through the LLM only adds latency and refusal
+                        // risk — we already know the exact `open(1)` invocation.
+                        // Falls through to the agent path when no direct match.
+                        if let action = ProactiveTaskExecute.directDesktopAction(
+                            title: notification.title,
+                            message: notification.message,
+                            context: notification.context
+                        ) {
+                            let notificationId = notification.id
+                            let titleForPill = notification.title
+                            FloatingControlBarManager.shared.dismissCurrentNotification()
+                            Task {
+                                _ = await AgentPillsManager.shared.spawnDirectActionForNotification(
+                                    notificationId: notificationId,
+                                    query: query,
+                                    model: model,
+                                    title: titleForPill,
+                                    action: action
+                                )
+                            }
+                            return
+                        }
+
                         // Sprint 3 / P7 — preflight. The launchTelegram case
                         // is best-effort: ExecutePreflight already called
                         // `open -a Telegram`, so we proceed to spawn the

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -233,11 +233,14 @@ struct FloatingControlBarView: View {
                         // Safari, Finder, or a URL in a known browser). Routing
                         // these through the LLM only adds latency and refusal
                         // risk — we already know the exact `open(1)` invocation.
+                        // The detector intentionally ignores notification
+                        // context (sourceApp, reasoning, …) because those are
+                        // observational, not the user's stated intent — see
+                        // ProactiveTaskExecute.directDesktopAction docs.
                         // Falls through to the agent path when no direct match.
                         if let action = ProactiveTaskExecute.directDesktopAction(
                             title: notification.title,
-                            message: notification.message,
-                            context: notification.context
+                            message: notification.message
                         ) {
                             let notificationId = notification.id
                             let titleForPill = notification.title

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -484,14 +484,25 @@ enum ProactiveTaskExecute {
         // Closing brackets — strip only if the URL has more closes than
         // opens of that bracket type. Wikipedia URLs like
         // `/wiki/Foo_(bar)` are balanced and must survive.
-        for (open, close) in [("(", ")"), ("[", "]"), ("{", "}")] {
-            while url.hasSuffix(close) {
-                let opens = url.filter { String($0) == open }.count
-                let closes = url.filter { String($0) == close }.count
-                if closes > opens {
-                    url.removeLast()
-                } else {
-                    break
+        //
+        // Loop until a full pass over all bracket types removes nothing,
+        // so mixed trailing wrappers like `https://example.com)]` (a `)`
+        // from prose wrapping a `]` from prose) get fully cleaned —
+        // single-pass ordering would strip the inner bracket and leave
+        // the outer one behind.
+        var changed = true
+        while changed {
+            changed = false
+            for (open, close) in [("(", ")"), ("[", "]"), ("{", "}")] {
+                while url.hasSuffix(close) {
+                    let opens = url.filter { String($0) == open }.count
+                    let closes = url.filter { String($0) == close }.count
+                    if closes > opens {
+                        url.removeLast()
+                        changed = true
+                    } else {
+                        break
+                    }
                 }
             }
         }

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -150,6 +150,30 @@ enum ProactiveTaskExecute {
             .firstMatch(in: intentText, range: fullRange)
         guard appMatch != nil || urlMatch != nil else { return nil }
 
+        // Multi-step guard. If the user's imperative chains more work after
+        // the open phrase — e.g. "Open Chrome and send Daniel the summary"
+        // or "Launch Safari then check email" — defer to the agent path so
+        // that downstream work isn't silently dropped. We check only the
+        // text *after* the matched open phrase so coordinating conjunctions
+        // inside the matched URL (e.g. ".../path/and/more") don't false-trip.
+        // Conservative-by-design: a false positive (deferring something we
+        // could have fast-pathed) just costs an LLM round trip; a false
+        // negative drops user-requested work.
+        let matchEndUTF16: Int = {
+            if let m = appMatch { return NSMaxRange(m.range) }
+            if let m = urlMatch { return NSMaxRange(m.range) }
+            return (intentText as NSString).length
+        }()
+        let afterText = (intentText as NSString)
+            .substring(from: matchEndUTF16)
+        let multiStepPattern = #"\b(and|then|also)\b\s+\S"#
+        if afterText.range(
+            of: multiStepPattern,
+            options: [.regularExpression, .caseInsensitive]
+        ) != nil {
+            return nil
+        }
+
         // Browser inference, two-source rule. We only set `browserName`
         // when the user *explicitly* named a browser; otherwise we let
         // open(1) fall back to the system default. Two signals count:
@@ -188,8 +212,22 @@ enum ProactiveTaskExecute {
         // (if also present) just picks the browser via `browserName`.
         // URL is captured from the original intent text (not lowercased),
         // so case-sensitive paths and signed tokens survive intact.
+        //
+        // The `\S+` capture greedily includes terminal punctuation when a
+        // URL ends a sentence ("Open https://react.dev/learn."). Strip a
+        // small set of common closing characters off the tail before
+        // building the URL so we don't request the wrong path.
         if let urlMatch, let urlRange = Range(urlMatch.range(at: 1), in: intentText) {
-            if let url = URL(string: String(intentText[urlRange])) {
+            var urlString = String(intentText[urlRange])
+            let trailingPunctuation: Set<Character> = [
+                ".", ",", ";", "!", "?", ":",
+                ")", "]", "}",
+                "\"", "'",
+            ]
+            while let last = urlString.last, trailingPunctuation.contains(last) {
+                urlString.removeLast()
+            }
+            if let url = URL(string: urlString) {
                 return .openURL(url: url, browserName: browserName)
             }
         }

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -110,6 +110,26 @@ enum ProactiveTaskExecute {
         case openURL(url: URL, browserName: String?)
     }
 
+    /// Negation deferral pattern. If the user is telling us NOT to open
+    /// something ("Do not open Chrome", "Don't launch Safari", "Never
+    /// open Finder") the fast path would do the exact opposite of the
+    /// request. Defer to the agent path. Matches standalone negation
+    /// words ("not", "never", "cannot", "do not") and contraction
+    /// forms ending in `n't` (`don't`, `can't`, `won't`, `doesn't`,
+    /// `didn't`, `wouldn't`, `shouldn't`, `couldn't`, `isn't`, `wasn't`,
+    /// `aren't`, `weren't`, `hadn't`, `hasn't`, `haven't`, `needn't`,
+    /// `mustn't`). Curly apostrophes (`'`) are tolerated alongside
+    /// straight ones.
+    private static let negationPattern =
+        #"(?i)\b(?:not|never|cannot|do\s+not|"# +
+        #"don['’]t|doesn['’]t|didn['’]t|"# +
+        #"won['’]t|can['’]t|"# +
+        #"isn['’]t|wasn['’]t|aren['’]t|weren['’]t|"# +
+        #"wouldn['’]t|shouldn['’]t|couldn['’]t|"# +
+        #"hadn['’]t|hasn['’]t|haven['’]t|"# +
+        #"needn['’]t|mustn['’]t"# +
+        #")\b"#
+
     /// Multi-step deferral pattern (fast-path → LLM fallback). Triggers on:
     /// - a coordinating conjunction (`and|then|also`) followed by content, or
     /// - any secondary action verb that suggests more work after the open.
@@ -207,6 +227,20 @@ enum ProactiveTaskExecute {
         if scanText.range(
             of: multiStepPattern,
             options: [.regularExpression, .caseInsensitive]
+        ) != nil {
+            return nil
+        }
+        // Negation guard. "Do not open Chrome" / "Don't launch Safari"
+        // must defer — the fast path would otherwise do the exact
+        // opposite of the user's stated intent. Scope to scanText (the
+        // text outside the matched verb-target span) so a URL whose
+        // path or query happens to contain a token like "cannot" doesn't
+        // false-trip. Conservative-by-design: a false positive defers
+        // an open we could have run; a false negative opens an app
+        // against the user's explicit instruction.
+        if scanText.range(
+            of: negationPattern,
+            options: [.regularExpression]
         ) != nil {
             return nil
         }

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -343,9 +343,16 @@ enum ProactiveTaskExecute {
     /// are more closes than opens in the URL).
     private static func trimTrailingNoise(from rawURL: String) -> String {
         var url = rawURL
-        // Unambiguous sentence terminators that never appear at the end
-        // of a real URL.
-        let always: Set<Character> = [".", ",", ";", "!", "?", ":", "\"", "'"]
+        // Strip-always set is intentionally narrow: only characters that
+        // are extremely uncommon at the end of a real URL but very
+        // common as sentence punctuation. `:`, `;`, `'` were considered
+        // and rejected — they're valid URL syntax (port / scheme
+        // delimiter, matrix params, RFC 3986 sub-delim) and legitimately
+        // appear at the end of paths like `/mailto:`, `/topic;v=1`. The
+        // cost of NOT stripping a sentence-final `:` is a malformed URL
+        // request the OS rejects; the cost of stripping a *valid* `:`
+        // is opening the wrong resource. Choose correctness over noise.
+        let always: Set<Character> = [".", ",", "!", "?", "\""]
         while let last = url.last, always.contains(last) {
             url.removeLast()
         }

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -235,8 +235,22 @@ enum ProactiveTaskExecute {
                 return String(intentText[captureRange])
             }
         )
-        if uniqueAppTargets.count + uniqueUrls.count > 1 {
-            return nil
+
+        // Two or more distinct app targets — clearly multi-step
+        // ("Open Chrome and Safari" wants both Chrome and Safari).
+        if uniqueAppTargets.count > 1 { return nil }
+        // Two or more distinct URLs — also multi-step.
+        if uniqueUrls.count > 1 { return nil }
+        // App + URL — defer UNLESS the app is a browser, in which case
+        // "Open Chrome" + "Open https://x in Chrome" collapses to the
+        // single deterministic action `open -a Chrome https://x`. The
+        // URL routing below picks up `browserName` from the app-phrase
+        // capture or the "in <browser>" suffix and emits the combined
+        // `.openURL(url, browserName)` action.
+        if !uniqueAppTargets.isEmpty && !uniqueUrls.isEmpty {
+            let appTarget = uniqueAppTargets.first ?? ""
+            let isBrowser = appTarget == "google chrome" || appTarget == "safari"
+            if !isBrowser { return nil }
         }
 
         // Multi-step guard. If the user's imperative chains more work after

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -149,7 +149,17 @@ enum ProactiveTaskExecute {
         #"update|change|edit|modify|set|add|"# +
         #"remind|notify|"# +
         #"buy|order|purchase|"# +
-        #"save|download|upload"# +
+        #"save|download|upload|"# +
+        // Common follow-up imperatives flagged in PR review. Deferred
+        // because each is an unambiguous second instruction the agent
+        // path should handle, not the host-side `open(1)` call. Verbs
+        // that double as research/lookup ("find", "look", "search",
+        // "view", "get") are intentionally NOT in this set — those
+        // tend to describe a goal *within* the just-opened app and
+        // fast-path is acceptable.
+        #"check|read|close|call|"# +
+        #"play|pause|stop|start|restart|kill|quit|"# +
+        #"refresh|sync|switch|sign|log"# +
         #")\b"#
 
     /// Inspect a notification's user-meaningful imperative for a

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -271,22 +271,18 @@ enum ProactiveTaskExecute {
         //    summary"` + `message: "Open Chrome"` (no conjunction, work
         //    appears *before* the open phrase) also defers.
         //
-        // The scan excludes the matched span itself so URL content with
-        // literal "and"/"send" in a path (e.g. ".../this-and-that",
-        // "/send/") doesn't false-trip the deferral.
+        // The scan excludes EVERY matched span — app match AND URL match
+        // when both are present — so URL path tokens like
+        // `/this-and-that` or `/send/` can't false-trip the deferral
+        // when paired with a browser-app match like "Open Chrome".
         //
         // Conservative-by-design: a false positive (deferring something we
         // could have fast-pathed) just costs an LLM round trip; a false
         // negative silently drops user-requested work.
-        let nsIntent = intentText as NSString
-        let matchedRange: NSRange = {
-            if let appMatch { return appMatch.range }
-            if let urlMatch { return urlMatch.range }
-            return NSRange(location: 0, length: 0)
-        }()
-        let beforeText = nsIntent.substring(to: matchedRange.location)
-        let afterText = nsIntent.substring(from: NSMaxRange(matchedRange))
-        let scanText = beforeText + " " + afterText
+        let scanText = redactedScanText(
+            from: intentText,
+            excluding: (appMatches + urlMatches).map { $0.range }
+        )
         if scanText.range(
             of: multiStepPattern,
             options: [.regularExpression, .caseInsensitive]
@@ -438,6 +434,38 @@ enum ProactiveTaskExecute {
     /// use `]`). Strip unambiguous sentence punctuation always, and
     /// strip closing brackets only when they're *unmatched* (i.e. there
     /// are more closes than opens in the URL).
+    /// Build a "scan text" from the intent with every matched span
+    /// redacted to a single space. Used by the multi-step / negation
+    /// guards so URL path tokens (e.g. `/this-and-that`, `/send/`) and
+    /// the matched verb phrase itself can't false-trip the scans.
+    ///
+    /// Ranges may overlap or be unsorted; both are handled.
+    private static func redactedScanText(from text: String, excluding ranges: [NSRange]) -> String {
+        let validRanges = ranges
+            .compactMap { Range($0, in: text) }
+            .sorted { $0.lowerBound < $1.lowerBound }
+        guard !validRanges.isEmpty else { return text }
+
+        var result = ""
+        var cursor = text.startIndex
+        for range in validRanges {
+            // Already past this range from a previous (overlapping) one.
+            guard range.lowerBound >= cursor else {
+                cursor = max(cursor, range.upperBound)
+                continue
+            }
+            if cursor < range.lowerBound {
+                result.append(contentsOf: text[cursor..<range.lowerBound])
+            }
+            result.append(" ")
+            cursor = range.upperBound
+        }
+        if cursor < text.endIndex {
+            result.append(contentsOf: text[cursor..<text.endIndex])
+        }
+        return result
+    }
+
     private static func trimTrailingNoise(from rawURL: String) -> String {
         var url = rawURL
         // Strip-always set is intentionally narrow: only characters that

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -110,6 +110,26 @@ enum ProactiveTaskExecute {
         case openURL(url: URL, browserName: String?)
     }
 
+    /// Multi-step deferral pattern (fast-path → LLM fallback). Triggers on:
+    /// - a coordinating conjunction (`and|then|also`) followed by content, or
+    /// - any secondary action verb that suggests more work after the open.
+    /// Kept as a single alternation regex so the check is one pass.
+    /// `open` is intentionally excluded — we already matched it as the
+    /// primary verb; including it would defer "Open Chrome please open
+    /// quickly" (rare, but unambiguously single-action).
+    private static let multiStepPattern =
+        #"\b(?:and|then|also|"# +
+        #"send|reply|respond|message|text|email|ping|dm|"# +
+        #"create|make|build|generate|draft|compose|write|"# +
+        #"schedule|book|plan|"# +
+        #"post|publish|share|"# +
+        #"remove|delete|"# +
+        #"update|change|edit|modify|set|add|"# +
+        #"remind|notify|"# +
+        #"buy|order|purchase|"# +
+        #"save|download|upload"# +
+        #")\b"#
+
     /// Inspect a notification's user-meaningful imperative for a
     /// high-confidence "open X" intent. Returns nil whenever in doubt — the
     /// agent path is always the fallback, so a missed match merely degrades
@@ -151,22 +171,34 @@ enum ProactiveTaskExecute {
         guard appMatch != nil || urlMatch != nil else { return nil }
 
         // Multi-step guard. If the user's imperative chains more work after
-        // the open phrase — e.g. "Open Chrome and send Daniel the summary"
-        // or "Launch Safari then check email" — defer to the agent path so
-        // that downstream work isn't silently dropped. We check only the
-        // text *after* the matched open phrase so coordinating conjunctions
-        // inside the matched URL (e.g. ".../path/and/more") don't false-trip.
+        // the open phrase — e.g. "Open Chrome and send Daniel the summary",
+        // "Launch Safari then check email", or just "Open Chrome" + "Send
+        // Daniel ..." in separate title/message fields with no conjunction
+        // at all — defer to the agent path so downstream work isn't
+        // silently dropped. Two signals trigger deferral:
+        //
+        // 1. A coordinating conjunction (`and|then|also`) followed by
+        //    content. Catches "Open Chrome and Safari" where the trailing
+        //    target isn't a recognized action verb.
+        // 2. Any *secondary action verb* in the text after the matched open
+        //    phrase. Catches sentence-break and title/message-split
+        //    multi-step cases like "Open Chrome. Send Daniel ..." that
+        //    have no leading conjunction.
+        //
+        // Both checks are scoped to text *after* the matched open phrase
+        // so a URL whose path contains the literal "and" or "send" (e.g.
+        // ".../this-and-that", "/send/") doesn't false-trip.
+        //
         // Conservative-by-design: a false positive (deferring something we
         // could have fast-pathed) just costs an LLM round trip; a false
-        // negative drops user-requested work.
+        // negative silently drops user-requested work.
         let matchEndUTF16: Int = {
-            if let m = appMatch { return NSMaxRange(m.range) }
-            if let m = urlMatch { return NSMaxRange(m.range) }
+            if let appMatch { return NSMaxRange(appMatch.range) }
+            if let urlMatch { return NSMaxRange(urlMatch.range) }
             return (intentText as NSString).length
         }()
         let afterText = (intentText as NSString)
             .substring(from: matchEndUTF16)
-        let multiStepPattern = #"\b(and|then|also)\b\s+\S"#
         if afterText.range(
             of: multiStepPattern,
             options: [.regularExpression, .caseInsensitive]
@@ -212,21 +244,8 @@ enum ProactiveTaskExecute {
         // (if also present) just picks the browser via `browserName`.
         // URL is captured from the original intent text (not lowercased),
         // so case-sensitive paths and signed tokens survive intact.
-        //
-        // The `\S+` capture greedily includes terminal punctuation when a
-        // URL ends a sentence ("Open https://react.dev/learn."). Strip a
-        // small set of common closing characters off the tail before
-        // building the URL so we don't request the wrong path.
         if let urlMatch, let urlRange = Range(urlMatch.range(at: 1), in: intentText) {
-            var urlString = String(intentText[urlRange])
-            let trailingPunctuation: Set<Character> = [
-                ".", ",", ";", "!", "?", ":",
-                ")", "]", "}",
-                "\"", "'",
-            ]
-            while let last = urlString.last, trailingPunctuation.contains(last) {
-                urlString.removeLast()
-            }
+            let urlString = trimTrailingNoise(from: String(intentText[urlRange]))
             if let url = URL(string: urlString) {
                 return .openURL(url: url, browserName: browserName)
             }
@@ -296,6 +315,38 @@ enum ProactiveTaskExecute {
     static func completionActivityText(from text: String) -> String {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "Done" : trimmed
+    }
+
+    /// Trim trailing sentence-noise off a captured URL. The capture is
+    /// `\S+`, which greedily includes any closing characters at the end
+    /// of the surrounding sentence — but those characters are sometimes
+    /// part of the URL (Wikipedia disambig paths end in `)`, regex docs
+    /// use `]`). Strip unambiguous sentence punctuation always, and
+    /// strip closing brackets only when they're *unmatched* (i.e. there
+    /// are more closes than opens in the URL).
+    private static func trimTrailingNoise(from rawURL: String) -> String {
+        var url = rawURL
+        // Unambiguous sentence terminators that never appear at the end
+        // of a real URL.
+        let always: Set<Character> = [".", ",", ";", "!", "?", ":", "\"", "'"]
+        while let last = url.last, always.contains(last) {
+            url.removeLast()
+        }
+        // Closing brackets — strip only if the URL has more closes than
+        // opens of that bracket type. Wikipedia URLs like
+        // `/wiki/Foo_(bar)` are balanced and must survive.
+        for (open, close) in [("(", ")"), ("[", "]"), ("{", "}")] {
+            while url.hasSuffix(close) {
+                let opens = url.filter { String($0) == open }.count
+                let closes = url.filter { String($0) == close }.count
+                if closes > opens {
+                    url.removeLast()
+                } else {
+                    break
+                }
+            }
+        }
+        return url
     }
 
     /// Sprint 3 / P8 — programmatic verification follow-up. Fired on the same

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -105,7 +105,7 @@ enum ProactiveTaskExecute {
     /// apps and URLs. Detected at the Execute click site so we can short
     /// the highest-confidence intents straight to `open(1)` instead of
     /// paying for a model round trip that can refuse.
-    enum DirectDesktopAction: Equatable {
+    enum DirectDesktopAction: Equatable, Sendable {
         case openApplication(name: String)
         case openURL(url: URL, browserName: String?)
     }
@@ -183,23 +183,28 @@ enum ProactiveTaskExecute {
         // 2. Any *secondary action verb* in the text after the matched open
         //    phrase. Catches sentence-break and title/message-split
         //    multi-step cases like "Open Chrome. Send Daniel ..." that
-        //    have no leading conjunction.
+        //    have no leading conjunction. Both BEFORE and AFTER the match
+        //    are scanned, so an intent like `title: "Send Daniel the
+        //    summary"` + `message: "Open Chrome"` (no conjunction, work
+        //    appears *before* the open phrase) also defers.
         //
-        // Both checks are scoped to text *after* the matched open phrase
-        // so a URL whose path contains the literal "and" or "send" (e.g.
-        // ".../this-and-that", "/send/") doesn't false-trip.
+        // The scan excludes the matched span itself so URL content with
+        // literal "and"/"send" in a path (e.g. ".../this-and-that",
+        // "/send/") doesn't false-trip the deferral.
         //
         // Conservative-by-design: a false positive (deferring something we
         // could have fast-pathed) just costs an LLM round trip; a false
         // negative silently drops user-requested work.
-        let matchEndUTF16: Int = {
-            if let appMatch { return NSMaxRange(appMatch.range) }
-            if let urlMatch { return NSMaxRange(urlMatch.range) }
-            return (intentText as NSString).length
+        let nsIntent = intentText as NSString
+        let matchedRange: NSRange = {
+            if let appMatch { return appMatch.range }
+            if let urlMatch { return urlMatch.range }
+            return NSRange(location: 0, length: 0)
         }()
-        let afterText = (intentText as NSString)
-            .substring(from: matchEndUTF16)
-        if afterText.range(
+        let beforeText = nsIntent.substring(to: matchedRange.location)
+        let afterText = nsIntent.substring(from: NSMaxRange(matchedRange))
+        let scanText = beforeText + " " + afterText
+        if scanText.range(
             of: multiStepPattern,
             options: [.regularExpression, .caseInsensitive]
         ) != nil {
@@ -271,42 +276,54 @@ enum ProactiveTaskExecute {
         return nil
     }
 
-    /// Execute a direct desktop action via `/usr/bin/open`. Returns a short
-    /// human-readable summary suitable for the pill's `latestActivity`.
-    /// Throws on non-zero exit so the caller can surface the failure.
+    /// Execute a direct desktop action via `/usr/bin/open`. Returns a
+    /// short human-readable summary suitable for the pill's
+    /// `latestActivity`. Throws on non-zero exit so the caller can
+    /// surface the failure.
+    ///
+    /// The subprocess (`process.run()` + `process.waitUntilExit()`) is
+    /// run inside `Task.detached` so callers on `@MainActor` (the
+    /// floating-bar button, the bridge dispatch) don't block the main
+    /// thread for the duration of `open(1)`. App-launch can take a
+    /// second on a cold start; stalling the UI on that is unacceptable.
     static func perform(_ action: DirectDesktopAction) async throws -> String {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        switch action {
-        case .openApplication(let name):
-            process.arguments = ["-a", name]
-        case .openURL(let url, let browserName):
-            if let browserName, !browserName.isEmpty {
-                process.arguments = ["-a", browserName, url.absoluteString]
-            } else {
-                process.arguments = [url.absoluteString]
+        try await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+            switch action {
+            case .openApplication(let name):
+                process.arguments = ["-a", name]
+            case .openURL(let url, let browserName):
+                if let browserName, !browserName.isEmpty {
+                    process.arguments = ["-a", browserName, url.absoluteString]
+                } else {
+                    process.arguments = [url.absoluteString]
+                }
             }
-        }
 
-        try process.run()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            throw NSError(
-                domain: "ProactiveTaskExecute",
-                code: Int(process.terminationStatus),
-                userInfo: [NSLocalizedDescriptionKey: "open exited with status \(process.terminationStatus)"]
-            )
-        }
-
-        switch action {
-        case .openApplication(let name):
-            return "Opened \(name)."
-        case .openURL(let url, let browserName):
-            if let browserName, !browserName.isEmpty {
-                return "Opened \(url.absoluteString) in \(browserName)."
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else {
+                throw NSError(
+                    domain: "ProactiveTaskExecute",
+                    code: Int(process.terminationStatus),
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "open exited with status \(process.terminationStatus)"
+                    ]
+                )
             }
-            return "Opened \(url.absoluteString)."
-        }
+
+            switch action {
+            case .openApplication(let name):
+                return "Opened \(name)."
+            case .openURL(let url, let browserName):
+                if let browserName, !browserName.isEmpty {
+                    return "Opened \(url.absoluteString) in \(browserName)."
+                }
+                return "Opened \(url.absoluteString)."
+            }
+        }.value
     }
 
     /// Normalize a pill's terminal activity text — trim, fall back to "Done"

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -128,9 +128,7 @@ enum ProactiveTaskExecute {
     ) -> DirectDesktopAction? {
         let intentText = (title + " " + message)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let lower = intentText.lowercased()
-        let nsLower = lower as NSString
-        let fullRange = NSRange(location: 0, length: nsLower.length)
+        let fullRange = NSRange(location: 0, length: (intentText as NSString).length)
 
         // Strict adjacency guard. The verb ("open"/"launch") must sit next
         // to a recognized target, separated only by a small filler word
@@ -138,31 +136,60 @@ enum ProactiveTaskExecute {
         // "tabs I have open in Chrome" or "the launch I'm planning" —
         // those have "open"/"launch" in the text but not as an imperative
         // adjacent to a known target.
+        //
+        // Patterns match case-insensitively against the *original* intent
+        // text so URL capture preserves the original case — critical for
+        // case-sensitive paths, query params, and signed tokens.
         let appPattern = #"\b(?:open|launch)(?:\s+(?:up|the|a))?\s+(google chrome|chrome|safari|finder|react docs)\b"#
         let urlPattern = #"\b(?:open|launch)(?:\s+(?:up|the|a))?\s+(https?://\S+)"#
+        let opts: NSRegularExpression.Options = [.caseInsensitive]
 
-        let appMatch = (try? NSRegularExpression(pattern: appPattern))?
-            .firstMatch(in: lower, range: fullRange)
-        let urlMatch = (try? NSRegularExpression(pattern: urlPattern))?
-            .firstMatch(in: lower, range: fullRange)
+        let appMatch = (try? NSRegularExpression(pattern: appPattern, options: opts))?
+            .firstMatch(in: intentText, range: fullRange)
+        let urlMatch = (try? NSRegularExpression(pattern: urlPattern, options: opts))?
+            .firstMatch(in: intentText, range: fullRange)
         guard appMatch != nil || urlMatch != nil else { return nil }
 
-        // Pick the requested browser. With the guard above we know the
-        // user used an imperative; a mentioned browser name now reliably
-        // signals routing intent (e.g. "Open https://x in Safari").
-        let browserName: String?
-        if lower.contains("chrome") || lower.contains("google chrome") {
-            browserName = "Google Chrome"
-        } else if lower.contains("safari") {
-            browserName = "Safari"
-        } else {
-            browserName = nil
+        // Browser inference, two-source rule. We only set `browserName`
+        // when the user *explicitly* named a browser; otherwise we let
+        // open(1) fall back to the system default. Two signals count:
+        //
+        // 1. The app-phrase regex captured "chrome"/"safari" — the user
+        //    wrote "Open Chrome" or "Launch Safari" directly.
+        // 2. The intent contains an "in <Browser>" suffix — anchored by
+        //    `\bin\s+` so it can't match inside hostnames like
+        //    `developer.chrome.com` or `safari-extensions.example.com`.
+        //
+        // Substring scans like `lower.contains("chrome")` are wrong here:
+        // they hijack any URL whose host happens to mention a browser.
+        var browserName: String?
+        if let appMatch,
+           let captureRange = Range(appMatch.range(at: 1), in: intentText) {
+            switch String(intentText[captureRange]).lowercased() {
+            case "google chrome", "chrome":
+                browserName = "Google Chrome"
+            case "safari":
+                browserName = "Safari"
+            default:
+                break
+            }
+        }
+        if browserName == nil {
+            let chromeSuffix = #"\bin\s+(?:google\s+)?chrome\b"#
+            let safariSuffix = #"\bin\s+safari\b"#
+            if intentText.range(of: chromeSuffix, options: [.regularExpression, .caseInsensitive]) != nil {
+                browserName = "Google Chrome"
+            } else if intentText.range(of: safariSuffix, options: [.regularExpression, .caseInsensitive]) != nil {
+                browserName = "Safari"
+            }
         }
 
         // "open <URL>" — primary target is the URL itself; the app phrase
         // (if also present) just picks the browser via `browserName`.
-        if let urlMatch, let urlRange = Range(urlMatch.range(at: 1), in: lower) {
-            if let url = URL(string: String(lower[urlRange])) {
+        // URL is captured from the original intent text (not lowercased),
+        // so case-sensitive paths and signed tokens survive intact.
+        if let urlMatch, let urlRange = Range(urlMatch.range(at: 1), in: intentText) {
+            if let url = URL(string: String(intentText[urlRange])) {
                 return .openURL(url: url, browserName: browserName)
             }
         }
@@ -170,8 +197,8 @@ enum ProactiveTaskExecute {
         // Otherwise the user explicitly named an app. Route by the exact
         // target the regex captured, so an incidental link in the body
         // never overrides an explicit app open.
-        if let appMatch, let targetRange = Range(appMatch.range(at: 1), in: lower) {
-            switch String(lower[targetRange]) {
+        if let appMatch, let targetRange = Range(appMatch.range(at: 1), in: intentText) {
+            switch String(intentText[targetRange]).lowercased() {
             case "google chrome", "chrome":
                 return .openApplication(name: "Google Chrome")
             case "safari":
@@ -231,17 +258,6 @@ enum ProactiveTaskExecute {
     static func completionActivityText(from text: String) -> String {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "Done" : trimmed
-    }
-
-    private static func firstURL(in text: String) -> URL? {
-        guard
-            let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue),
-            let match = detector.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
-            let url = match.url
-        else {
-            return nil
-        }
-        return url
     }
 
     /// Sprint 3 / P8 — programmatic verification follow-up. Fired on the same

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -99,6 +99,122 @@ enum ProactiveTaskExecute {
         """
     }
 
+    // MARK: - Direct-action fast path
+
+    /// Deterministic local actions that don't need an LLM turn — opening
+    /// apps and URLs. Detected at the Execute click site so we can short
+    /// the highest-confidence intents straight to `open(1)` instead of
+    /// paying for a model round trip that can refuse.
+    enum DirectDesktopAction: Equatable {
+        case openApplication(name: String)
+        case openURL(url: URL, browserName: String?)
+    }
+
+    /// Inspect a notification's title/message/context for a high-confidence
+    /// "open X" intent. Returns nil whenever in doubt — the agent path is
+    /// always the fallback, so a missed match merely degrades to today's
+    /// behavior. A false positive would surprise the user, so the matcher
+    /// only fires when the verbs *and* targets are unambiguous.
+    static func directDesktopAction(
+        title: String,
+        message: String,
+        context: FloatingBarNotificationContext? = nil
+    ) -> DirectDesktopAction? {
+        let combined = [
+            title,
+            message,
+            context?.sourceApp ?? "",
+            context?.windowTitle ?? "",
+            context?.contextSummary ?? "",
+            context?.currentActivity ?? "",
+            context?.reasoning ?? "",
+            context?.detail ?? "",
+        ]
+        .joined(separator: " ")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let lower = combined.lowercased()
+        guard lower.contains("open") || lower.contains("launch") else { return nil }
+
+        let browserName = lower.contains("chrome") || lower.contains("google chrome")
+            ? "Google Chrome"
+            : nil
+        if let url = firstURL(in: combined) {
+            return .openURL(url: url, browserName: browserName)
+        }
+        if lower.contains("react") && lower.contains("docs") {
+            return .openURL(url: URL(string: "https://react.dev")!, browserName: browserName)
+        }
+
+        if lower.contains("google chrome") || lower.contains("chrome") {
+            return .openApplication(name: "Google Chrome")
+        }
+        if lower.contains("safari") {
+            return .openApplication(name: "Safari")
+        }
+        if lower.contains("finder") {
+            return .openApplication(name: "Finder")
+        }
+        return nil
+    }
+
+    /// Execute a direct desktop action via `/usr/bin/open`. Returns a short
+    /// human-readable summary suitable for the pill's `latestActivity`.
+    /// Throws on non-zero exit so the caller can surface the failure.
+    static func perform(_ action: DirectDesktopAction) async throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        switch action {
+        case .openApplication(let name):
+            process.arguments = ["-a", name]
+        case .openURL(let url, let browserName):
+            if let browserName, !browserName.isEmpty {
+                process.arguments = ["-a", browserName, url.absoluteString]
+            } else {
+                process.arguments = [url.absoluteString]
+            }
+        }
+
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw NSError(
+                domain: "ProactiveTaskExecute",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "open exited with status \(process.terminationStatus)"]
+            )
+        }
+
+        switch action {
+        case .openApplication(let name):
+            return "Opened \(name)."
+        case .openURL(let url, let browserName):
+            if let browserName, !browserName.isEmpty {
+                return "Opened \(url.absoluteString) in \(browserName)."
+            }
+            return "Opened \(url.absoluteString)."
+        }
+    }
+
+    /// Normalize a pill's terminal activity text — trim, fall back to "Done"
+    /// when empty. Kept here so direct-action and LLM-path pills share the
+    /// same shape.
+    static func completionActivityText(from text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Done" : trimmed
+    }
+
+    private static func firstURL(in text: String) -> URL? {
+        guard
+            let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue),
+            let match = detector.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+            let url = match.url
+        else {
+            return nil
+        }
+        return url
+    }
+
     /// Sprint 3 / P8 — programmatic verification follow-up. Fired on the same
     /// warm session after the main turn returns and the local verification
     /// gate (P2) says a write tool was called. Forces the model to produce

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -131,12 +131,14 @@ enum ProactiveTaskExecute {
         #")\b"#
 
     /// Multi-step deferral pattern (fast-path → LLM fallback). Triggers on:
-    /// - a coordinating conjunction (`and|then|also`) followed by content, or
+    /// - a coordinating conjunction (`and|then|also`), or
     /// - any secondary action verb that suggests more work after the open.
     /// Kept as a single alternation regex so the check is one pass.
-    /// `open` is intentionally excluded — we already matched it as the
-    /// primary verb; including it would defer "Open Chrome please open
-    /// quickly" (rare, but unambiguously single-action).
+    /// `open|launch` are intentionally NOT in this list — a title that
+    /// labels the task ("Open page") naturally repeats the primary verb
+    /// in the message ("Open https://…") without it being multi-step.
+    /// The "multiple distinct open commands" case is handled separately
+    /// by counting regex matches.
     private static let multiStepPattern =
         #"\b(?:and|then|also|"# +
         #"send|reply|respond|message|text|email|ping|dm|"# +
@@ -184,11 +186,48 @@ enum ProactiveTaskExecute {
         let urlPattern = #"\b(?:open|launch)(?:\s+(?:up|the|a))?\s+(https?://\S+)"#
         let opts: NSRegularExpression.Options = [.caseInsensitive]
 
-        let appMatch = (try? NSRegularExpression(pattern: appPattern, options: opts))?
-            .firstMatch(in: intentText, range: fullRange)
-        let urlMatch = (try? NSRegularExpression(pattern: urlPattern, options: opts))?
-            .firstMatch(in: intentText, range: fullRange)
+        let appMatches = (try? NSRegularExpression(pattern: appPattern, options: opts))?
+            .matches(in: intentText, range: fullRange) ?? []
+        let urlMatches = (try? NSRegularExpression(pattern: urlPattern, options: opts))?
+            .matches(in: intentText, range: fullRange) ?? []
+        let appMatch = appMatches.first
+        let urlMatch = urlMatches.first
         guard appMatch != nil || urlMatch != nil else { return nil }
+
+        // Multiple distinct open targets — "Open Chrome. Open Safari",
+        // "Open Finder, open https://...", etc. The fast path can only
+        // deliver one open per pill; defer to the agent path so every
+        // requested target is honored.
+        //
+        // We compare *targets*, not raw match counts: a notification
+        // whose `title="Open Safari"` and `message="Launch Safari
+        // please"` matches twice but resolves to the same target
+        // ({safari}) and is unambiguously single-action. Counting
+        // matches naïvely deferred those legitimate single-intent
+        // cases.
+        let uniqueAppTargets: Set<String> = Set(
+            appMatches.compactMap { match -> String? in
+                guard
+                    let captureRange = Range(match.range(at: 1), in: intentText)
+                else { return nil }
+                let raw = String(intentText[captureRange]).lowercased()
+                switch raw {
+                case "google chrome", "chrome": return "google chrome"
+                default: return raw
+                }
+            }
+        )
+        let uniqueUrls: Set<String> = Set(
+            urlMatches.compactMap { match -> String? in
+                guard
+                    let captureRange = Range(match.range(at: 1), in: intentText)
+                else { return nil }
+                return String(intentText[captureRange])
+            }
+        )
+        if uniqueAppTargets.count + uniqueUrls.count > 1 {
+            return nil
+        }
 
         // Multi-step guard. If the user's imperative chains more work after
         // the open phrase — e.g. "Open Chrome and send Daniel the summary",

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -110,50 +110,79 @@ enum ProactiveTaskExecute {
         case openURL(url: URL, browserName: String?)
     }
 
-    /// Inspect a notification's title/message/context for a high-confidence
-    /// "open X" intent. Returns nil whenever in doubt — the agent path is
-    /// always the fallback, so a missed match merely degrades to today's
-    /// behavior. A false positive would surprise the user, so the matcher
-    /// only fires when the verbs *and* targets are unambiguous.
+    /// Inspect a notification's user-meaningful imperative for a
+    /// high-confidence "open X" intent. Returns nil whenever in doubt — the
+    /// agent path is always the fallback, so a missed match merely degrades
+    /// to today's behavior. A false positive would surprise the user, so
+    /// the matcher only fires when the verbs *and* targets are unambiguous.
+    ///
+    /// Scope note: we deliberately ignore `FloatingBarNotificationContext`
+    /// (`sourceApp`, `windowTitle`, `reasoning`, `detail`, …) — those are
+    /// observational, not the user's stated intent. Including them led to
+    /// false positives like "Summarize the tabs I have **open** in
+    /// **Chrome**" hijacking the fast path. The `title` and `message` carry
+    /// the imperative; nothing else.
     static func directDesktopAction(
         title: String,
-        message: String,
-        context: FloatingBarNotificationContext? = nil
+        message: String
     ) -> DirectDesktopAction? {
-        let combined = [
-            title,
-            message,
-            context?.sourceApp ?? "",
-            context?.windowTitle ?? "",
-            context?.contextSummary ?? "",
-            context?.currentActivity ?? "",
-            context?.reasoning ?? "",
-            context?.detail ?? "",
-        ]
-        .joined(separator: " ")
-        .trimmingCharacters(in: .whitespacesAndNewlines)
+        let intentText = (title + " " + message)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = intentText.lowercased()
+        let nsLower = lower as NSString
+        let fullRange = NSRange(location: 0, length: nsLower.length)
 
-        let lower = combined.lowercased()
-        guard lower.contains("open") || lower.contains("launch") else { return nil }
+        // Strict adjacency guard. The verb ("open"/"launch") must sit next
+        // to a recognized target, separated only by a small filler word
+        // ("up", "the", "a"). Rejects descriptive uses like
+        // "tabs I have open in Chrome" or "the launch I'm planning" —
+        // those have "open"/"launch" in the text but not as an imperative
+        // adjacent to a known target.
+        let appPattern = #"\b(?:open|launch)(?:\s+(?:up|the|a))?\s+(google chrome|chrome|safari|finder|react docs)\b"#
+        let urlPattern = #"\b(?:open|launch)(?:\s+(?:up|the|a))?\s+(https?://\S+)"#
 
-        let browserName = lower.contains("chrome") || lower.contains("google chrome")
-            ? "Google Chrome"
-            : nil
-        if let url = firstURL(in: combined) {
-            return .openURL(url: url, browserName: browserName)
-        }
-        if lower.contains("react") && lower.contains("docs") {
-            return .openURL(url: URL(string: "https://react.dev")!, browserName: browserName)
+        let appMatch = (try? NSRegularExpression(pattern: appPattern))?
+            .firstMatch(in: lower, range: fullRange)
+        let urlMatch = (try? NSRegularExpression(pattern: urlPattern))?
+            .firstMatch(in: lower, range: fullRange)
+        guard appMatch != nil || urlMatch != nil else { return nil }
+
+        // Pick the requested browser. With the guard above we know the
+        // user used an imperative; a mentioned browser name now reliably
+        // signals routing intent (e.g. "Open https://x in Safari").
+        let browserName: String?
+        if lower.contains("chrome") || lower.contains("google chrome") {
+            browserName = "Google Chrome"
+        } else if lower.contains("safari") {
+            browserName = "Safari"
+        } else {
+            browserName = nil
         }
 
-        if lower.contains("google chrome") || lower.contains("chrome") {
-            return .openApplication(name: "Google Chrome")
+        // "open <URL>" — primary target is the URL itself; the app phrase
+        // (if also present) just picks the browser via `browserName`.
+        if let urlMatch, let urlRange = Range(urlMatch.range(at: 1), in: lower) {
+            if let url = URL(string: String(lower[urlRange])) {
+                return .openURL(url: url, browserName: browserName)
+            }
         }
-        if lower.contains("safari") {
-            return .openApplication(name: "Safari")
-        }
-        if lower.contains("finder") {
-            return .openApplication(name: "Finder")
+
+        // Otherwise the user explicitly named an app. Route by the exact
+        // target the regex captured, so an incidental link in the body
+        // never overrides an explicit app open.
+        if let appMatch, let targetRange = Range(appMatch.range(at: 1), in: lower) {
+            switch String(lower[targetRange]) {
+            case "google chrome", "chrome":
+                return .openApplication(name: "Google Chrome")
+            case "safari":
+                return .openApplication(name: "Safari")
+            case "finder":
+                return .openApplication(name: "Finder")
+            case "react docs":
+                return .openURL(url: URL(string: "https://react.dev")!, browserName: browserName)
+            default:
+                return nil
+            }
         }
         return nil
     }

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -328,6 +328,135 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         )
     }
 
+    // MARK: - Multi-step deferral (Codex P1, fix v4)
+
+    /// Review feedback (Codex P1): the prior detector matched any
+    /// `open <target>` even when the user chained additional work
+    /// ("Open Chrome **and send Daniel the summary**"). Firing the fast
+    /// path on such an intent silently drops the send step — the LLM is
+    /// never invoked. Multi-step intents must defer.
+    func testDirectDesktopActionDefersOnAndConjunction() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Chrome and send Daniel the standup summary"
+            ),
+            "multi-step task must defer so the 'send Daniel' step isn't silently dropped"
+        )
+    }
+
+    func testDirectDesktopActionDefersOnThenConjunction() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Launch Safari then check email"
+            )
+        )
+    }
+
+    func testDirectDesktopActionDefersOnTwoOpenTargets() {
+        // Two opens is still multi-step — the fast path can only deliver
+        // one open. Defer so the agent can pick.
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Chrome and Safari"
+            )
+        )
+    }
+
+    func testDirectDesktopActionDefersOnAlsoFollowup() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Finder. Also reply to Sarah."
+            )
+        )
+    }
+
+    func testDirectDesktopActionStillFastPathsPoliteSuffix() {
+        // "please" / "for me" / trailing politeness are not multi-step
+        // signals. Fast-path should still fire.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Chrome please"
+            ),
+            .openApplication(name: "Google Chrome")
+        )
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Chrome for me"
+            ),
+            .openApplication(name: "Google Chrome")
+        )
+    }
+
+    func testDirectDesktopActionConjunctionInsideUrlDoesNotDefer() {
+        // The multi-step check runs only against text *after* the matched
+        // open phrase. A URL whose path happens to contain "and"
+        // (/this-and-that) must not trigger the multi-step deferral.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open https://example.com/this-and-that"
+            ),
+            .openURL(
+                url: URL(string: "https://example.com/this-and-that")!,
+                browserName: nil
+            )
+        )
+    }
+
+    // MARK: - URL trailing-punctuation stripping (Codex P2, fix v4)
+
+    /// Review feedback (Codex P2): `\S+` greedily includes terminal
+    /// punctuation when a URL ends a sentence. Without the strip the
+    /// fast path opens the wrong path or fails outright.
+    func testDirectDesktopActionStripsTrailingPeriodFromUrl() {
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open the docs",
+                message: "Open https://react.dev/learn."
+            ),
+            .openURL(url: URL(string: "https://react.dev/learn")!, browserName: nil)
+        )
+    }
+
+    func testDirectDesktopActionStripsTrailingCloseParen() {
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open it",
+                message: "Open https://example.com)"
+            ),
+            .openURL(url: URL(string: "https://example.com")!, browserName: nil)
+        )
+    }
+
+    func testDirectDesktopActionStripsMultipleTrailingPunctuationMarks() {
+        // Sentence-ending punctuation can compound. Strip all of them.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open https://example.com/path?!"
+            ),
+            .openURL(url: URL(string: "https://example.com/path")!, browserName: nil)
+        )
+    }
+
+    func testDirectDesktopActionDoesNotStripValidUrlPathCharacters() {
+        // A trailing slash is part of the URL, not punctuation — must
+        // NOT be stripped.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open https://example.com/"
+            ),
+            .openURL(url: URL(string: "https://example.com/")!, browserName: nil)
+        )
+    }
+
     func testCompletionActivityTextDoesNotTruncateFinalMessage() {
         let long = String(repeating: "Final task result with enough detail. ", count: 8)
         XCTAssertEqual(

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -694,6 +694,57 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         )
     }
 
+    // MARK: - Multiple open verbs (Codex P1, fix v9)
+
+    /// Review feedback (Codex P1 on v8): the multi-step deferral pattern
+    /// omitted `open|launch`, so a sequence of opens like
+    /// "Open Chrome. Open Safari" matched the first phrase, fast-pathed
+    /// to Chrome, and silently dropped the Safari open. Sequences with
+    /// multiple targets must defer so the agent can deliver every step.
+    func testDirectDesktopActionDefersOnTwoSequentialOpens() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Chrome. Open Safari"
+            ),
+            "two open commands is a sequence the fast path can't deliver"
+        )
+    }
+
+    func testDirectDesktopActionDefersOnOpenAppPlusOpenUrl() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Finder, open https://example.com"
+            )
+        )
+    }
+
+    func testDirectDesktopActionDefersOnLaunchPlusOpen() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Launch Finder then open Chrome"
+            )
+        )
+    }
+
+    func testDirectDesktopActionStillFastPathsSingleOpenWithNoSequel() {
+        // Sanity check: a single open without another open verb still
+        // fast-paths. The primary matched span is excluded from the
+        // scan so it doesn't self-trip the new `open|launch` deferral.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open page",
+                message: "Open https://example.dev/path in Safari"
+            ),
+            .openURL(
+                url: URL(string: "https://example.dev/path")!,
+                browserName: "Safari"
+            )
+        )
+    }
+
     // MARK: - URL trailing-punctuation stripping (Codex P2, fix v4)
 
     /// Review feedback (Codex P2): `\S+` greedily includes terminal

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -470,6 +470,47 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         )
     }
 
+    // MARK: - Multi-step deferral: text BEFORE the match (Codex P1, fix v6)
+
+    /// Review feedback (Codex P1 on v5): the v5 scan only inspected
+    /// `afterText`. A title/message split that puts the secondary work
+    /// *before* the open phrase — e.g. title="Send Daniel the summary",
+    /// message="Open Chrome" — left `afterText` empty and false-passed
+    /// the guard. The scan must now cover BOTH sides of the match.
+    func testDirectDesktopActionDefersOnSecondaryWorkBeforeOpen() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Send Daniel the standup summary",
+                message: "Open Chrome"
+            ),
+            "secondary work in the title (before the open phrase) must defer too"
+        )
+    }
+
+    func testDirectDesktopActionDefersOnSecondaryVerbBeforeMatchSameField() {
+        // Single message field, secondary verb appears before the open.
+        // Pre-fix this fast-pathed because afterText was empty.
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Reply to Sarah. Open Chrome."
+            )
+        )
+    }
+
+    func testDirectDesktopActionStillFastPathsTitleSaysTaskBeforeOpen() {
+        // Production shape (title="Task") plus before-match scan must
+        // still fast-path "Task" / "Open Chrome" — "task" isn't a
+        // secondary action verb.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Chrome"
+            ),
+            .openApplication(name: "Google Chrome")
+        )
+    }
+
     // MARK: - Matched-parenthesis URL preservation (Codex P2, fix v5)
 
     /// Review feedback (Codex P2, v4 follow-up): the v4 trailing-strip

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -142,4 +142,86 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         XCTAssertTrue(s.contains("Never claim \"done\" without proof"))
         XCTAssertTrue(s.contains("PREFERRED CHANNELS"))
     }
+
+    // MARK: - Direct desktop action detector (Chrome refusal fix)
+
+    func testDirectDesktopActionDetectsOpenChromeTask() {
+        let action = ProactiveTaskExecute.directDesktopAction(
+            title: "Open Chrome",
+            message: "Open Google Chrome so I can continue browsing.",
+            context: nil
+        )
+        XCTAssertEqual(action, .openApplication(name: "Google Chrome"))
+    }
+
+    func testDirectDesktopActionDetectsUrlInChromeTask() {
+        let action = ProactiveTaskExecute.directDesktopAction(
+            title: "Open docs",
+            message: "Open https://react.dev/learn in Chrome",
+            context: nil
+        )
+        XCTAssertEqual(
+            action,
+            .openURL(url: URL(string: "https://react.dev/learn")!, browserName: "Google Chrome")
+        )
+    }
+
+    func testDirectDesktopActionMapsReactDocsRequestToReactURL() {
+        let action = ProactiveTaskExecute.directDesktopAction(
+            title: "Task",
+            message: "Open the React docs in Chrome",
+            context: nil
+        )
+        XCTAssertEqual(
+            action,
+            .openURL(url: URL(string: "https://react.dev")!, browserName: "Google Chrome")
+        )
+    }
+
+    func testDirectDesktopActionDetectsSafari() {
+        let action = ProactiveTaskExecute.directDesktopAction(
+            title: "Open Safari",
+            message: "Launch Safari",
+            context: nil
+        )
+        XCTAssertEqual(action, .openApplication(name: "Safari"))
+    }
+
+    func testDirectDesktopActionDetectsFinder() {
+        let action = ProactiveTaskExecute.directDesktopAction(
+            title: "Open Finder",
+            message: "Show me Finder",
+            context: nil
+        )
+        XCTAssertEqual(action, .openApplication(name: "Finder"))
+    }
+
+    func testDirectDesktopActionIgnoresUnrelatedTasks() {
+        // Conservative-by-design: anything without "open" or "launch" + a
+        // known target must defer to the agent path.
+        let nilCases: [(String, String)] = [
+            ("Send Daniel the standup summary", "Daniel asked for the bullet summary."),
+            ("Create /tmp/file.txt", "Write 'hello' to a file"),
+            ("Schedule lunch with Anna", "Block 12:30-1:30 tomorrow"),
+        ]
+        for (title, message) in nilCases {
+            XCTAssertNil(
+                ProactiveTaskExecute.directDesktopAction(title: title, message: message, context: nil),
+                "expected no direct-action match for: \(title)"
+            )
+        }
+    }
+
+    func testCompletionActivityTextDoesNotTruncateFinalMessage() {
+        let long = String(repeating: "Final task result with enough detail. ", count: 8)
+        XCTAssertEqual(
+            ProactiveTaskExecute.completionActivityText(from: long),
+            long.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    func testCompletionActivityTextFallsBackToDoneOnEmptyInput() {
+        XCTAssertEqual(ProactiveTaskExecute.completionActivityText(from: ""), "Done")
+        XCTAssertEqual(ProactiveTaskExecute.completionActivityText(from: "   \n  "), "Done")
+    }
 }

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -915,6 +915,57 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         )
     }
 
+    // MARK: - Mixed unmatched trailing brackets (Codex P2, fix v13)
+
+    /// Review feedback (Codex P2): `trimTrailingNoise` iterated through
+    /// bracket pairs in a single fixed order, so a mixed wrapper like
+    /// `)]` only stripped the inner `]` and left `)` behind. Loop until
+    /// no bracket is removed so every unmatched closer gets cleaned.
+    func testDirectDesktopActionStripsMixedUnmatchedTrailingBrackets() {
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open page",
+                message: "Open https://example.com)]"
+            ),
+            .openURL(url: URL(string: "https://example.com")!, browserName: nil)
+        )
+    }
+
+    func testDirectDesktopActionStripsMixedUnmatchedTrailingBracketsReversed() {
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open page",
+                message: "Open https://example.com])"
+            ),
+            .openURL(url: URL(string: "https://example.com")!, browserName: nil)
+        )
+    }
+
+    func testDirectDesktopActionStripsAllThreeMixedClosers() {
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open page",
+                message: "Open https://example.com})]"
+            ),
+            .openURL(url: URL(string: "https://example.com")!, browserName: nil)
+        )
+    }
+
+    func testDirectDesktopActionPreservesMixedBalancedBrackets() {
+        // Both bracket pairs are balanced inside the URL — neither
+        // closer should be stripped, even with the new loop.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open page",
+                message: "Open https://example.com/foo_(bar)[baz]"
+            ),
+            .openURL(
+                url: URL(string: "https://example.com/foo_(bar)[baz]")!,
+                browserName: nil
+            )
+        )
+    }
+
     // MARK: - URL trailing-punctuation stripping (Codex P2, fix v4)
 
     /// Review feedback (Codex P2): `\S+` greedily includes terminal

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -815,6 +815,54 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         )
     }
 
+    // MARK: - Browser + URL treated as single action (Codex P2, fix v11)
+
+    /// Review feedback (Codex P2): the naïve distinct-target guard
+    /// deferred whenever an app target and a URL both appeared. But
+    /// `title="Open Chrome"` + `message="Open https://example.dev in
+    /// Chrome"` is a single deterministic action: `open -a Chrome
+    /// https://example.dev`. Deferring it reintroduced the LLM-path
+    /// refusal class this PR exists to fix. App+URL is now fast-pathed
+    /// when the app is a browser; otherwise still deferred.
+    func testDirectDesktopActionFastPathsBrowserAppPlusUrlSingleIntent() {
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open Chrome",
+                message: "Open https://example.dev in Chrome"
+            ),
+            .openURL(
+                url: URL(string: "https://example.dev")!,
+                browserName: "Google Chrome"
+            ),
+            "open-chrome title + open-URL-in-chrome message is a single intent — must fast-path"
+        )
+    }
+
+    func testDirectDesktopActionFastPathsLaunchSafariPlusUrlSingleIntent() {
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open Safari",
+                message: "Open https://example.dev/path in Safari"
+            ),
+            .openURL(
+                url: URL(string: "https://example.dev/path")!,
+                browserName: "Safari"
+            )
+        )
+    }
+
+    func testDirectDesktopActionDefersOnNonBrowserAppPlusUrl() {
+        // Finder isn't a browser — combining "Open Finder" with a URL
+        // is two disparate intents. Defer.
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open Finder",
+                message: "Open https://example.com"
+            ),
+            "non-browser app + URL = two disparate intents → defer"
+        )
+    }
+
     // MARK: - URL trailing-punctuation stripping (Codex P2, fix v4)
 
     /// Review feedback (Codex P2): `\S+` greedily includes terminal

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -616,6 +616,84 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         )
     }
 
+    // MARK: - Negation deferral (Codex P1, fix v8)
+
+    /// Review feedback (Codex P1): the matcher accepts any `open|launch`
+    /// phrase without checking for nearby negation, so a task like
+    /// "Do not open Chrome" or "Don't launch Safari" still triggers
+    /// the fast path — running `/usr/bin/open` against the user's
+    /// explicit instruction. The negation guard now defers on
+    /// `not|never|cannot|do not` and on any `n't`-style contraction.
+    func testDirectDesktopActionDefersOnDoNotOpen() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Do not open Chrome"
+            ),
+            "negated open intent must defer — fast-pathing it would do the exact opposite of the user's request"
+        )
+    }
+
+    func testDirectDesktopActionDefersOnDontLaunch() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Don't launch Safari"
+            )
+        )
+    }
+
+    func testDirectDesktopActionDefersOnCurlyApostropheContraction() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Don\u{2019}t open Finder"
+            ),
+            "curly apostrophe (U+2019) in contractions must also defer"
+        )
+    }
+
+    func testDirectDesktopActionDefersOnNeverOpen() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Never open Chrome from this notification"
+            )
+        )
+    }
+
+    func testDirectDesktopActionDefersOnCannotOpen() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "You cannot open Safari for me here"
+            )
+        )
+    }
+
+    func testDirectDesktopActionDefersOnNegationAfterMatch() {
+        // Negation appearing AFTER the matched phrase should also
+        // defer — "Open Chrome but don't send anything" implies
+        // multi-step + negation, both reasons to route to the agent.
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Chrome but don't send anything"
+            )
+        )
+    }
+
+    func testDirectDesktopActionStillFastPathsWithoutNegation() {
+        // Sanity check: removing the negation makes it fast-path again.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Chrome"
+            ),
+            .openApplication(name: "Google Chrome")
+        )
+    }
+
     // MARK: - URL trailing-punctuation stripping (Codex P2, fix v4)
 
     /// Review feedback (Codex P2): `\S+` greedily includes terminal

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -574,6 +574,48 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         )
     }
 
+    // MARK: - Preserve valid trailing URL syntax (Codex P2, fix v7)
+
+    /// Review feedback (Codex P2 on v6): `:`, `;`, `'` are valid URL
+    /// characters and were being stripped unconditionally. Trailing
+    /// `:` appears in URLs ending with `/mailto:` or in port/scheme
+    /// delimiter contexts; trailing `;` shows up in matrix-param
+    /// paths; `'` is RFC 3986 sub-delim and can appear in path/query.
+    /// The strip-always set is now narrowed to characters that are
+    /// extremely uncommon at the end of real URLs (`. , ! ? "`).
+    func testDirectDesktopActionPreservesTrailingColon() {
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open",
+                message: "Open https://example.com/topic:"
+            ),
+            .openURL(url: URL(string: "https://example.com/topic:")!, browserName: nil)
+        )
+    }
+
+    func testDirectDesktopActionPreservesTrailingSemicolon() {
+        // Matrix-param style path component — `;` is valid syntax.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open",
+                message: "Open https://example.com/path;v=1"
+            ),
+            .openURL(url: URL(string: "https://example.com/path;v=1")!, browserName: nil)
+        )
+    }
+
+    func testDirectDesktopActionPreservesTrailingApostrophe() {
+        // RFC 3986 sub-delim. Rare in real URLs but valid; err on the
+        // side of correctness rather than stripping.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open",
+                message: "Open https://example.com/it's"
+            ),
+            .openURL(url: URL(string: "https://example.com/it's")!, browserName: nil)
+        )
+    }
+
     // MARK: - URL trailing-punctuation stripping (Codex P2, fix v4)
 
     /// Review feedback (Codex P2): `\S+` greedily includes terminal

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -863,6 +863,58 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         )
     }
 
+    // MARK: - URL content excluded from scan when app match also exists (Codex P2, fix v12)
+
+    /// Review feedback (Codex P2): the v11 scan only excluded the
+    /// first matched span (the app match when both exist), leaving
+    /// the URL in `scanText`. Path tokens like `/this-and-that` or
+    /// `/send/` then false-tripped `multiStepPattern`'s `\band\b` and
+    /// `\bsend\b`, deferring legitimate browser+URL intents. The
+    /// scan now redacts every matched span (app AND URL) so URL
+    /// content can't false-trip.
+    func testDirectDesktopActionBrowserAppPlusUrlNotTrippedByUrlPathConjunction() {
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open Chrome",
+                message: "Open https://example.com/this-and-that in Chrome"
+            ),
+            .openURL(
+                url: URL(string: "https://example.com/this-and-that")!,
+                browserName: "Google Chrome"
+            ),
+            "URL path token 'and' must not trigger multi-step deferral when paired with a browser app match"
+        )
+    }
+
+    func testDirectDesktopActionBrowserAppPlusUrlNotTrippedByUrlPathVerb() {
+        // `/send/` inside a URL path used to match `\bsend\b` in the
+        // multi-step pattern when paired with a browser app match.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open Chrome",
+                message: "Open https://example.com/api/send/v1 in Chrome"
+            ),
+            .openURL(
+                url: URL(string: "https://example.com/api/send/v1")!,
+                browserName: "Google Chrome"
+            )
+        )
+    }
+
+    func testDirectDesktopActionMultipleMatchSpansAllExcludedFromScan() {
+        // Both spans get redacted — no false-trip on either side.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open Safari",
+                message: "Open https://example.com/post/share-and-create in Safari"
+            ),
+            .openURL(
+                url: URL(string: "https://example.com/post/share-and-create")!,
+                browserName: "Safari"
+            )
+        )
+    }
+
     // MARK: - URL trailing-punctuation stripping (Codex P2, fix v4)
 
     /// Review feedback (Codex P2): `\S+` greedily includes terminal

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -745,6 +745,76 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         )
     }
 
+    // MARK: - Expanded follow-up verb deferral (Codex P1, fix v10)
+
+    /// Review feedback (Codex P1 on v9): the multi-step verb list
+    /// omitted common follow-up imperatives — `check`, `read`, `close`,
+    /// `call`, etc. — so phrasings like "Open Chrome. Check email."
+    /// fast-pathed the open and dropped the second instruction.
+    func testDirectDesktopActionDefersOnCheckFollowup() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Chrome. Check email."
+            ),
+            "'Check email' must defer — fast-pathing the open silently drops the second step"
+        )
+    }
+
+    func testDirectDesktopActionDefersOnCloseFollowup() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Chrome. Close Slack."
+            )
+        )
+    }
+
+    func testDirectDesktopActionDefersOnCallFollowup() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open FaceTime to call Daniel"
+            )
+        )
+    }
+
+    func testDirectDesktopActionDefersOnReadFollowup() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Chrome. Read the launch notes."
+            )
+        )
+    }
+
+    func testDirectDesktopActionDefersOnPlayPauseStop() {
+        for verb in ["play", "pause", "stop", "restart"] {
+            XCTAssertNil(
+                ProactiveTaskExecute.directDesktopAction(
+                    title: "Task",
+                    message: "Open Music to \(verb) the track"
+                ),
+                "follow-up verb '\(verb)' must defer"
+            )
+        }
+    }
+
+    func testDirectDesktopActionStillFastPathsOnPureResearchVerb() {
+        // Research-y verbs (`find`, `look`, `search`, `view`, `get`)
+        // remain intentionally out of the multi-step set — they tend
+        // to describe a goal *within* the just-opened app, and the
+        // fast-path open is acceptable. Pin so a future "add them
+        // all" reflex catches this trade-off.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open Finder",
+                message: "Open Finder to find the budget doc"
+            ),
+            .openApplication(name: "Finder")
+        )
+    }
+
     // MARK: - URL trailing-punctuation stripping (Codex P2, fix v4)
 
     /// Review feedback (Codex P2): `\S+` greedily includes terminal

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -259,6 +259,75 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         )
     }
 
+    /// Review feedback (Codex P1): the prior detector lowercased the whole
+    /// intent text and built the URL from the lowercased slice, mangling
+    /// case-sensitive paths, query params, and signed tokens. URL casing
+    /// must survive intact end-to-end.
+    func testDirectDesktopActionPreservesUrlCasing() {
+        let action = ProactiveTaskExecute.directDesktopAction(
+            title: "Open file",
+            message: "Open https://example.com/ApiKey/AbC123?Sig=XyZ"
+        )
+        XCTAssertEqual(
+            action,
+            .openURL(
+                url: URL(string: "https://example.com/ApiKey/AbC123?Sig=XyZ")!,
+                browserName: nil
+            )
+        )
+    }
+
+    /// Review feedback (Codex P2): the prior `lower.contains("chrome")`
+    /// scan matched substrings inside hostnames like `developer.chrome.com`
+    /// and forced Chrome even when the user didn't ask for it. Browser
+    /// inference must require explicit phrasing — the URL host alone is
+    /// not consent to override the system default browser.
+    func testDirectDesktopActionDoesNotHijackBrowserFromUrlHost() {
+        let chromeHost = ProactiveTaskExecute.directDesktopAction(
+            title: "Open docs",
+            message: "Open https://developer.chrome.com/docs/extensions"
+        )
+        XCTAssertEqual(
+            chromeHost,
+            .openURL(
+                url: URL(string: "https://developer.chrome.com/docs/extensions")!,
+                browserName: nil
+            ),
+            "URL host containing 'chrome' must not pick Chrome as the browser"
+        )
+
+        let safariHost = ProactiveTaskExecute.directDesktopAction(
+            title: "Open page",
+            message: "Open https://safari-extensions.example.com/release-notes"
+        )
+        XCTAssertEqual(
+            safariHost,
+            .openURL(
+                url: URL(string: "https://safari-extensions.example.com/release-notes")!,
+                browserName: nil
+            ),
+            "URL host containing 'safari' must not pick Safari as the browser"
+        )
+    }
+
+    /// Companion: confirms the explicit "in <Browser>" suffix still routes
+    /// correctly even when the URL host doesn't mention any browser — so
+    /// we know the inference fix didn't accidentally break the supported
+    /// "open <URL> in Chrome" pattern.
+    func testDirectDesktopActionRoutesUrlToChromeViaSuffix() {
+        let action = ProactiveTaskExecute.directDesktopAction(
+            title: "Open page",
+            message: "Open https://example.dev/path in Google Chrome"
+        )
+        XCTAssertEqual(
+            action,
+            .openURL(
+                url: URL(string: "https://example.dev/path")!,
+                browserName: "Google Chrome"
+            )
+        )
+    }
+
     func testCompletionActivityTextDoesNotTruncateFinalMessage() {
         let long = String(repeating: "Final task result with enough detail. ", count: 8)
         XCTAssertEqual(

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -409,6 +409,130 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         )
     }
 
+    // MARK: - Multi-step deferral without conjunction (Codex P1, fix v5)
+
+    /// Review feedback (Codex P1, v4 follow-up): the conjunction-only
+    /// guard missed cases where the secondary work isn't introduced by
+    /// `and|then|also`. Example: title="Open Chrome", message="Send
+    /// Daniel the summary" — no conjunction, but unambiguously two
+    /// steps. The post-match scan must also look for any action verb
+    /// that suggests additional work, not just conjunctions.
+    func testDirectDesktopActionDefersOnSecondaryActionVerbNoConjunction() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open Chrome",
+                message: "Send Daniel the standup summary"
+            ),
+            "an action verb after the matched open phrase must defer, even without a conjunction"
+        )
+    }
+
+    func testDirectDesktopActionDefersOnSentenceBreakSecondaryVerb() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Finder. Reply to Sarah."
+            )
+        )
+    }
+
+    func testDirectDesktopActionDefersOnPostMatchScheduleVerb() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Task",
+                message: "Open Chrome to schedule the design review"
+            )
+        )
+    }
+
+    func testDirectDesktopActionStillFastPathsResearchVerbAfterMatch() {
+        // "find", "look up" etc. are research verbs — not in our
+        // secondary-action set. They shouldn't cause deferral; the LLM
+        // wouldn't make a write side effect for them anyway.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open Finder",
+                message: "Open Finder to find the budget doc"
+            ),
+            .openApplication(name: "Finder")
+        )
+    }
+
+    func testDirectDesktopActionStillFastPathsBareUrlInMessage() {
+        // No secondary verbs, no conjunctions — the URL is the entire
+        // imperative. Fast-path must still fire.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open",
+                message: "https://example.com"
+            ),
+            .openURL(url: URL(string: "https://example.com")!, browserName: nil)
+        )
+    }
+
+    // MARK: - Matched-parenthesis URL preservation (Codex P2, fix v5)
+
+    /// Review feedback (Codex P2, v4 follow-up): the v4 trailing-strip
+    /// always removed `)`, breaking real URLs whose path ends in `)` —
+    /// Wikipedia disambiguation pages being the canonical example.
+    /// Closing brackets must only be stripped when they're *unmatched*.
+    func testDirectDesktopActionPreservesBalancedWikipediaParens() {
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open page",
+                message: "Open https://en.wikipedia.org/wiki/Foo_(disambiguation)"
+            ),
+            .openURL(
+                url: URL(string: "https://en.wikipedia.org/wiki/Foo_(disambiguation)")!,
+                browserName: nil
+            )
+        )
+    }
+
+    func testDirectDesktopActionStripsTrailingPeriodAfterBalancedParens() {
+        // Sentence period after a valid balanced-paren URL must still be
+        // stripped, but the paren must survive.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open page",
+                message: "Open https://en.wikipedia.org/wiki/Foo_(bar)."
+            ),
+            .openURL(
+                url: URL(string: "https://en.wikipedia.org/wiki/Foo_(bar)")!,
+                browserName: nil
+            )
+        )
+    }
+
+    func testDirectDesktopActionStripsExtraUnmatchedClosingParen() {
+        // The URL has one balanced (..) pair plus one extra ) from a
+        // wrapping parenthetical in the prose. Strip the unmatched
+        // outer one; keep the inner balanced pair.
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open page",
+                message: "Open https://en.wikipedia.org/wiki/Foo_(bar))"
+            ),
+            .openURL(
+                url: URL(string: "https://en.wikipedia.org/wiki/Foo_(bar)")!,
+                browserName: nil
+            )
+        )
+    }
+
+    func testDirectDesktopActionPreservesBalancedBracketsInUrl() {
+        XCTAssertEqual(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Open",
+                message: "Open https://example.com/path[abc]"
+            ),
+            .openURL(
+                url: URL(string: "https://example.com/path[abc]")!,
+                browserName: nil
+            )
+        )
+    }
+
     // MARK: - URL trailing-punctuation stripping (Codex P2, fix v4)
 
     /// Review feedback (Codex P2): `\S+` greedily includes terminal

--- a/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
+++ b/desktop/Desktop/Tests/ProactiveTaskExecuteTests.swift
@@ -148,8 +148,7 @@ final class ProactiveTaskExecuteTests: XCTestCase {
     func testDirectDesktopActionDetectsOpenChromeTask() {
         let action = ProactiveTaskExecute.directDesktopAction(
             title: "Open Chrome",
-            message: "Open Google Chrome so I can continue browsing.",
-            context: nil
+            message: "Open Google Chrome so I can continue browsing."
         )
         XCTAssertEqual(action, .openApplication(name: "Google Chrome"))
     }
@@ -157,8 +156,7 @@ final class ProactiveTaskExecuteTests: XCTestCase {
     func testDirectDesktopActionDetectsUrlInChromeTask() {
         let action = ProactiveTaskExecute.directDesktopAction(
             title: "Open docs",
-            message: "Open https://react.dev/learn in Chrome",
-            context: nil
+            message: "Open https://react.dev/learn in Chrome"
         )
         XCTAssertEqual(
             action,
@@ -169,8 +167,7 @@ final class ProactiveTaskExecuteTests: XCTestCase {
     func testDirectDesktopActionMapsReactDocsRequestToReactURL() {
         let action = ProactiveTaskExecute.directDesktopAction(
             title: "Task",
-            message: "Open the React docs in Chrome",
-            context: nil
+            message: "Open the React docs in Chrome"
         )
         XCTAssertEqual(
             action,
@@ -181,8 +178,7 @@ final class ProactiveTaskExecuteTests: XCTestCase {
     func testDirectDesktopActionDetectsSafari() {
         let action = ProactiveTaskExecute.directDesktopAction(
             title: "Open Safari",
-            message: "Launch Safari",
-            context: nil
+            message: "Launch Safari"
         )
         XCTAssertEqual(action, .openApplication(name: "Safari"))
     }
@@ -190,8 +186,7 @@ final class ProactiveTaskExecuteTests: XCTestCase {
     func testDirectDesktopActionDetectsFinder() {
         let action = ProactiveTaskExecute.directDesktopAction(
             title: "Open Finder",
-            message: "Show me Finder",
-            context: nil
+            message: "Show me Finder"
         )
         XCTAssertEqual(action, .openApplication(name: "Finder"))
     }
@@ -206,10 +201,62 @@ final class ProactiveTaskExecuteTests: XCTestCase {
         ]
         for (title, message) in nilCases {
             XCTAssertNil(
-                ProactiveTaskExecute.directDesktopAction(title: title, message: message, context: nil),
+                ProactiveTaskExecute.directDesktopAction(title: title, message: message),
                 "expected no direct-action match for: \(title)"
             )
         }
+    }
+
+    /// Review feedback (Gemini, P1): the prior detector mixed
+    /// notification-context fields (sourceApp, reasoning, detail…) into the
+    /// trigger string. A "Summarize the tabs I have open in Chrome" task
+    /// whose context happens to mention "open" + "chrome" would get
+    /// hijacked. The detector must now key strictly on title + message.
+    func testDirectDesktopActionDoesNotTriggerOnAmbientChromeMention() {
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Summarize my tabs",
+                message: "Give me a one-line summary of each tab I have open in Chrome right now."
+            ),
+            "the verb 'open' here describes a state, not an imperative — must defer to the agent"
+        )
+
+        XCTAssertNil(
+            ProactiveTaskExecute.directDesktopAction(
+                title: "Draft an email",
+                message: "Write Daniel a reply about the launch I'm planning."
+            ),
+            "'launch' as a noun in a draft task must not trigger the fast path"
+        )
+    }
+
+    /// Review feedback (Gemini, P1): "Open https://example.dev in Safari"
+    /// used to find the URL but set browserName=nil — routing to the system
+    /// default browser instead of Safari. Safari must be detected alongside
+    /// Chrome.
+    func testDirectDesktopActionRoutesUrlToSafariWhenRequested() {
+        let action = ProactiveTaskExecute.directDesktopAction(
+            title: "Open docs",
+            message: "Open https://example.dev in Safari"
+        )
+        XCTAssertEqual(
+            action,
+            .openURL(url: URL(string: "https://example.dev")!, browserName: "Safari")
+        )
+    }
+
+    func testDirectDesktopActionLeavesBrowserNilWhenUnspecified() {
+        // No browser mentioned → defer to the system default browser via
+        // open(1)'s no-app form. Encoded so a future "always pick Chrome"
+        // regression gets caught.
+        let action = ProactiveTaskExecute.directDesktopAction(
+            title: "Open the docs",
+            message: "Open https://example.dev"
+        )
+        XCTAssertEqual(
+            action,
+            .openURL(url: URL(string: "https://example.dev")!, browserName: nil)
+        )
     }
 
     func testCompletionActivityTextDoesNotTruncateFinalMessage() {
@@ -223,5 +270,22 @@ final class ProactiveTaskExecuteTests: XCTestCase {
     func testCompletionActivityTextFallsBackToDoneOnEmptyInput() {
         XCTAssertEqual(ProactiveTaskExecute.completionActivityText(from: ""), "Done")
         XCTAssertEqual(ProactiveTaskExecute.completionActivityText(from: "   \n  "), "Done")
+    }
+
+    /// Review feedback (Gemini P1 / Codex P2): a failed direct action must
+    /// surface as a `.failed` pill rather than a misleading `.done`. The
+    /// contract that makes that possible is `perform(_:)` throwing on a
+    /// non-zero `open(1)` exit. Pins that contract — if it ever stops
+    /// throwing for an unknown app, `spawnDirectActionForNotification`
+    /// silently regresses to "lying success" without any test failing.
+    func testPerformThrowsForUnknownApplication() async {
+        let unknownAppName = "OmiFastpathTestNonexistentApp987"
+        do {
+            _ = try await ProactiveTaskExecute.perform(.openApplication(name: unknownAppName))
+            XCTFail("perform should throw for an unknown application")
+        } catch {
+            // Expected. Error message comes from open(1)'s non-zero exit,
+            // which we surface back to the user verbatim.
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a host-side fast path on the Execute button: deterministic 'open Chrome / Safari / Finder / URL' intents resolve via `/usr/bin/open` (~30ms) instead of routing through the LLM, which currently refuses these and gets demoted by the verification gate.
- Shares the same 60s notification dedup slot as the LLM path so a double-click cannot launch Chrome twice or silently fall back to the model on the second click.
- Conservative-by-design detector: no match → unchanged agent path. False positives surprise users; missed matches just degrade to today's behavior.

## Why
Today's regression: clicking Execute on an "Open Chrome" notification routes to the LLM, model refuses with "I can't open applications", verification gate flags `unverified`, single retry exhausts, pill shows "Could not verify: …" — for a task we could have run ourselves in 30ms with no model spend. Routes the highest-confidence intents around the model entirely.

## Changes
- `ProactiveTaskExecute.directDesktopAction(title:message:context:) -> DirectDesktopAction?` — detector.
- `ProactiveTaskExecute.perform(_:) async throws -> String` — runs `/usr/bin/open`, returns activity text.
- `ProactiveTaskExecute.completionActivityText(from:)` — shared trim/fallback for pill activity.
- `AgentPillsManager.spawnDirectActionForNotification(notificationId:query:model:title:action:)` — dedup-aware shortcut that calls `perform` then `spawnCompletedDirectAction`.
- `AgentPillsManager.spawnCompletedDirectAction(...)` — terminal `.done` pill for already-completed host actions.
- `FloatingControlBarView` Execute button — calls the detector before preflight + spawn.

## Test plan
- [x] Unit: 8 new `ProactiveTaskExecuteTests` cover the detector (Chrome, URL-in-Chrome, React-docs shortcut, Safari, Finder, conservative-no-match cases) and `completionActivityText` boundary behavior.
- [x] Suite green: 40/40 across `ProactiveTaskExecuteTests`, `ExecutePreflightTests`, `ExecuteVerificationGateTests`, `DesktopAutomationExecuteTests`.
- [x] End-to-end against a signed local bundle: \`POST /execute/spawn { title: \"Open Chrome\", ... }\` returns \`status=done\`, \`latestActivity=\"Opened Google Chrome.\"\`, \`invokedToolNames=[]\` (no LLM call), \`attemptCount=1\`.
- [ ] Manual UI: click Execute on a real "Open Chrome" proactive task notification — verify Chrome activates and a \`.done\` pill lands.
- [ ] Manual dedup: double-click the Execute button quickly — verify only one pill appears.

## Out of scope (followups)
- Pill \`latestActivity\` showing truncated mid-stream tokens ("B…", "typin…") while \`.running\` — separate UI ticket.
- Additional direct-action targets (Notes, Calendar, Music, generic .app bundles) — start with the highest-frequency cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)