### PR TITLE
fix(desktop): suppress mid-stream tokens in agent pill activity strip

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed floating-bar agent pills showing truncated mid-stream tokens (e.g. \"B\u2026\" / \"typin\u2026\") while running"
+  ],
   "releases": [
     {
       "version": "0.11.421",

--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -815,14 +815,26 @@ final class AgentPillsManager: ObservableObject {
             pill.status = .running
         }
 
-        let activity = describeActivity(for: aiMessage)
+        let activity = Self.describeActivity(for: aiMessage)
         if !activity.isEmpty && activity != pill.latestActivity {
             pill.latestActivity = activity
             pill.transcript.append(activity)
         }
     }
 
-    private func describeActivity(for message: ChatMessage) -> String {
+    /// Pill-bar activity string for an AI message. Skips streaming text
+    /// blocks: while the model is mid-generation, partial chunks like
+    /// `"O"`, `"Op"`, `"Open"` would each become a new `latestActivity`
+    /// value, and the pill bar (`lineLimit(1)`) renders that as
+    /// `"O…"` / `"Op…"` / `"Open"` flickering — the "B…/typin…" bug
+    /// reported in the floating-bar screenshots. Tool calls still flow
+    /// because they're atomic once invoked. Once `isStreaming` flips
+    /// false, the final text takes over via the next `handle` callback
+    /// or via `complete()`.
+    ///
+    /// Static + internal so it can be unit-tested without touching
+    /// AgentPillsManager's singleton state.
+    static func describeActivity(for message: ChatMessage) -> String {
         for block in message.contentBlocks.reversed() {
             switch block {
             case .toolCall(_, let name, _, _, let input, _):
@@ -832,6 +844,8 @@ final class AgentPillsManager: ObservableObject {
                 }
                 return display
             case .text(_, let text):
+                // Suppress mid-stream text — see doc comment above.
+                guard !message.isStreaming else { continue }
                 let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !trimmed.isEmpty {
                     return String(trimmed.prefix(110))
@@ -840,8 +854,11 @@ final class AgentPillsManager: ObservableObject {
                 continue
             }
         }
+        // Fallback: use message.text only when the message has finished
+        // streaming. While streaming, return "Working…" so the bar shows
+        // a stable label until tools or final text arrive.
         let trimmedFallback = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedFallback.isEmpty {
+        if !message.isStreaming, !trimmedFallback.isEmpty {
             return String(trimmedFallback.prefix(110))
         }
         return "Working…"

--- a/desktop/Desktop/Tests/AgentPillActivityTests.swift
+++ b/desktop/Desktop/Tests/AgentPillActivityTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+@testable import Omi_Computer
+
+/// Pins `AgentPillsManager.describeActivity` so the floating-bar pill never
+/// regresses to displaying mid-stream partial text tokens (the "B…/typin…"
+/// bug from the original screenshots).
+@MainActor
+final class AgentPillActivityTests: XCTestCase {
+
+    // MARK: - Streaming text suppression
+
+    /// While the AI message is still streaming, partial text chunks must NOT
+    /// drive `latestActivity`. The pill bar is line-limited, so a chunk like
+    /// `"O"` would render as `"O…"` and a chunk like `"typing the response"`
+    /// would render mid-word. Fall back to "Working…" until tools or final
+    /// text arrive.
+    func testStreamingTextOnlyMessageFallsBackToWorking() {
+        let message = ChatMessage(
+            text: "B",
+            sender: .ai,
+            isStreaming: true,
+            contentBlocks: [.text(id: "t1", text: "B")]
+        )
+        XCTAssertEqual(AgentPillsManager.describeActivity(for: message), "Working…")
+    }
+
+    func testStreamingMidWordChunkFallsBackToWorking() {
+        let message = ChatMessage(
+            text: "typin",
+            sender: .ai,
+            isStreaming: true,
+            contentBlocks: [.text(id: "t1", text: "typin")]
+        )
+        XCTAssertEqual(AgentPillsManager.describeActivity(for: message), "Working…")
+    }
+
+    func testStreamingPartialSentenceFallsBackToWorking() {
+        // Even a multi-word partial — "Opening Chrome for you now." would
+        // be a regression. The bar bypasses the LLM's partial text and
+        // shows "Working…" until streaming finishes.
+        let message = ChatMessage(
+            text: "Opening Chrome for you now.",
+            sender: .ai,
+            isStreaming: true,
+            contentBlocks: [.text(id: "t1", text: "Opening Chrome for you now.")]
+        )
+        XCTAssertEqual(AgentPillsManager.describeActivity(for: message), "Working…")
+    }
+
+    /// Tool calls are atomic events (the model decides to invoke a tool, with
+    /// a fully-formed input) — these CAN drive `latestActivity` during
+    /// streaming. The pill bar showing "bash — open -a 'Google Chrome'" is
+    /// informative, not flickery.
+    func testStreamingMessageWithToolCallReturnsToolDisplay() {
+        let toolBlock = ChatContentBlock.toolCall(
+            id: "tc1",
+            name: "bash",
+            status: .running,
+            toolUseId: "tu1",
+            input: ToolCallInput(summary: #"open -a "Google Chrome""#, details: nil),
+            output: nil
+        )
+        let message = ChatMessage(
+            text: "",
+            sender: .ai,
+            isStreaming: true,
+            contentBlocks: [toolBlock]
+        )
+        // ChatContentBlock.displayName decorates tool names — we don't pin
+        // its exact output here, just that the activity contains the tool
+        // input summary AND doesn't fall back to "Working…" / partial text.
+        let activity = AgentPillsManager.describeActivity(for: message)
+        XCTAssertNotEqual(activity, "Working…")
+        XCTAssertTrue(
+            activity.contains(#"open -a "Google Chrome""#),
+            "expected tool input summary in activity, got: \(activity)"
+        )
+    }
+
+    /// When BOTH a tool call and a (streaming) text block are present, the
+    /// streaming text must be skipped and the tool call wins. Pre-fix, the
+    /// reversed iteration matched the last text block first and returned
+    /// its partial content.
+    func testStreamingMessageWithToolCallAndPartialTextPrefersToolCall() {
+        let blocks: [ChatContentBlock] = [
+            .toolCall(
+                id: "tc1",
+                name: "shell",
+                status: .completed,
+                toolUseId: "tu1",
+                input: ToolCallInput(summary: "open -a Finder", details: nil),
+                output: "0"
+            ),
+            // Trailing streaming text block — pre-fix the reversed scan hit
+            // this first and returned the partial token.
+            .text(id: "t1", text: "Opening Find"),
+        ]
+        let message = ChatMessage(
+            text: "Opening Find",
+            sender: .ai,
+            isStreaming: true,
+            contentBlocks: blocks
+        )
+        let activity = AgentPillsManager.describeActivity(for: message)
+        // Pre-fix this returned "Opening Find" (partial text). After:
+        // we get the tool description (whatever displayName produces),
+        // never the partial text.
+        XCTAssertFalse(activity.contains("Opening Find"), "must not surface partial streaming text; got: \(activity)")
+        XCTAssertTrue(activity.contains("open -a Finder"), "expected tool input in activity; got: \(activity)")
+    }
+
+    // MARK: - Non-streaming (finalized) text is still surfaced
+
+    /// Once the message finishes streaming, the final text takes over as
+    /// `latestActivity`. This is the non-flickery completion case the
+    /// fast-path button and the LLM path both rely on.
+    func testFinalizedTextMessageReturnsTextPrefix() {
+        let message = ChatMessage(
+            text: "Created /tmp/eval/file.txt with EXECUTE_OK.",
+            sender: .ai,
+            isStreaming: false,
+            contentBlocks: [
+                .text(id: "t1", text: "Created /tmp/eval/file.txt with EXECUTE_OK.")
+            ]
+        )
+        XCTAssertEqual(
+            AgentPillsManager.describeActivity(for: message),
+            "Created /tmp/eval/file.txt with EXECUTE_OK."
+        )
+    }
+
+    func testFinalizedTextMessageWithoutContentBlocksFallsBackToText() {
+        // Some message paths populate `text` without producing
+        // contentBlocks — the fallback branch must still emit the text
+        // when the message is finalized.
+        let message = ChatMessage(
+            text: "Done.",
+            sender: .ai,
+            isStreaming: false
+        )
+        XCTAssertEqual(AgentPillsManager.describeActivity(for: message), "Done.")
+    }
+
+    /// Even on finalized messages we never show >110 chars in the bar — it's
+    /// `lineLimit(1)` and 110 is plenty for the strip.
+    func testFinalizedLongTextIsTruncatedToOneTenChars() {
+        let body = String(repeating: "abcdefghij", count: 20) // 200 chars
+        let message = ChatMessage(
+            text: body,
+            sender: .ai,
+            isStreaming: false,
+            contentBlocks: [.text(id: "t1", text: body)]
+        )
+        XCTAssertEqual(
+            AgentPillsManager.describeActivity(for: message).count,
+            110
+        )
+    }
+
+    // MARK: - Empty / minimal messages
+
+    func testEmptyMessageReturnsWorkingFallback() {
+        let message = ChatMessage(
+            text: "",
+            sender: .ai,
+            isStreaming: true
+        )
+        XCTAssertEqual(AgentPillsManager.describeActivity(for: message), "Working…")
+    }
+
+    func testThinkingOnlyMessageReturnsWorkingFallback() {
+        // `.thinking` blocks are intentionally ignored — they're internal
+        // reasoning, not user-facing activity.
+        let message = ChatMessage(
+            text: "",
+            sender: .ai,
+            isStreaming: true,
+            contentBlocks: [.thinking(id: "th1", text: "let me think...")]
+        )
+        XCTAssertEqual(AgentPillsManager.describeActivity(for: message), "Working…")
+    }
+}


### PR DESCRIPTION
## Summary
- Floating-bar agent pills used to flicker through mid-stream tokens (`"B…"`, `"typin…"`, `"Chrome for you now."`) while running — the bug captured in the original sprint screenshots.
- Root cause: `AgentPillsManager.describeActivity` rewrote `pill.latestActivity` on every streaming text-block update. The pill strip is `lineLimit(1)`, so each chunk landed truncated.
- Fix: while `message.isStreaming` is true, skip `.text` blocks and fall back to either the latest atomic tool-call description or the stable `"Working…"` placeholder. Tool calls still flow during streaming because they're atomic.
- `describeActivity` lifted to `static internal` for unit testability.

## Behavior comparison

| Scenario | Before | After |
|---|---|---|
| LLM streaming `"Opening"` → `"Opening Chrome"` → `"Opening Chrome for you now."` | strip cycles through each chunk truncated to 1 char wide; user sees `"O…"`, `"Op…"`, … | strip holds `"Working…"` (or the latest tool-call name) until streaming finishes, then shows the final text |
| Tool call invoked mid-stream | tool description briefly shown, then overwritten by the next streaming text chunk | tool description stays in place until the next tool / completion |
| Message finalized | final text shown | same — no change |

## Test plan
- [x] **10 new unit tests** (`AgentPillActivityTests`) covering: streaming text only → `"Working…"`, mid-word chunk → `"Working…"`, partial sentence → `"Working…"`, streaming + tool call → tool wins, streaming + tool + partial text → tool still wins (the reversed-iteration regression), finalized text → text, long finalized text → 110-char truncation, empty streaming → `"Working…"`, thinking-only → `"Working…"`.
- [x] Full suite: **122/122** across `AgentPillActivityTests` + the four Execute-related suites.
- [ ] Manual smoke: trigger an LLM-path Execute pill and observe the strip never displays mid-word ellipsis. Bridge fast-path pills are unaffected (they land terminal `.done` immediately).

## Closes the original sprint loop
This is the second of the two issues in the original floating-bar screenshots (Chrome refused was the first, addressed by PRs #25 + #26 + #27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)