### PR TITLE
fix(desktop): stop re-prompting Screen Recording permission on every launch

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,6 @@
 {
   "unreleased": [
-    "Fixed the macOS app popping up the Screen Recording permission dialog on every launch when permission hadn't been granted"
+    "Fixed the macOS app repeatedly requesting Screen Recording permission on launch when it has not been granted"
   ],
   "releases": [
     {

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,7 +1,5 @@
 {
-  "unreleased": [
-    "Fixed the macOS app repeatedly requesting Screen Recording permission on launch when it has not been granted"
-  ],
+  "unreleased": [],
   "releases": [
     {
       "version": "0.11.423",

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed the macOS app popping up the Screen Recording permission dialog on every launch when permission hadn't been granted"
+  ],
   "releases": [
     {
       "version": "0.11.423",

--- a/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -263,13 +263,15 @@ public class ProactiveAssistantsPlugin: NSObject {
             // Do NOT request the permission here. This method is invoked
             // automatically on launch, on API-key load, on app re-activation, and
             // after sleep/unlock (screen analysis is enabled by default), so
-            // requesting here popped the macOS Screen Recording dialog on every
-            // login when permission hadn't been granted. The permission is now
-            // surfaced only by explicit user-initiated enable flows (menu bar,
-            // Settings, Sidebar and Rewind toggles, and onboarding), each of which
-            // opens System Settings / requests permission before reaching this
-            // point. If the user grants access out-of-band, the retry loop below
-            // and the app-active/auto-restart paths pick it up without prompting.
+            // requesting here surfaced the macOS Screen Recording dialog on every
+            // login while permission was ungranted. The permission is now handled
+            // only by explicit user-initiated enable flows before they reach this
+            // point: the menu-bar and Settings toggles deep-link to System Settings
+            // via openScreenRecordingPreferences(), the Sidebar and Rewind toggles
+            // additionally call requestAllScreenCapturePermissions() to trigger the
+            // prompt, and onboarding uses its dedicated permission step. If the user
+            // grants access out-of-band, the retry loop below and the
+            // app-active/auto-restart paths pick it up without prompting.
             if retryCount < maxRetries {
                 let delay = retryDelays[retryCount]
                 log("Screen recording permission not yet granted, retrying in \(delay)s (attempt \(retryCount + 1)/\(maxRetries))")

--- a/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -260,11 +260,16 @@ public class ProactiveAssistantsPlugin: NSObject {
         // Check screen recording permission (and update cache)
         refreshScreenRecordingPermission()
         guard hasScreenRecordingPermission else {
-            if retryCount == 0 {
-                // First attempt: request permissions and schedule retry
-                ScreenCaptureService.requestAllScreenCapturePermissions()
-            }
-
+            // Do NOT request the permission here. This method is invoked
+            // automatically on launch, on API-key load, on app re-activation, and
+            // after sleep/unlock (screen analysis is enabled by default), so
+            // requesting here popped the macOS Screen Recording dialog on every
+            // login when permission hadn't been granted. The permission is now
+            // surfaced only by explicit user-initiated enable flows (menu bar,
+            // Settings, Sidebar and Rewind toggles, and onboarding), each of which
+            // opens System Settings / requests permission before reaching this
+            // point. If the user grants access out-of-band, the retry loop below
+            // and the app-active/auto-restart paths pick it up without prompting.
             if retryCount < maxRetries {
                 let delay = retryDelays[retryCount]
                 log("Screen recording permission not yet granted, retrying in \(delay)s (attempt \(retryCount + 1)/\(maxRetries))")

--- a/desktop/macos/changelog/unreleased/20260704-screen-recording-permission-launch.json
+++ b/desktop/macos/changelog/unreleased/20260704-screen-recording-permission-launch.json
@@ -1,0 +1,3 @@
+{
+    "change": "Fixed the macOS app repeatedly requesting Screen Recording permission on launch when it has not been granted"
+}


### PR DESCRIPTION
## Problem

The macOS app asks the user to turn on / grant Screen Recording **every time they log in**.

The reported premise was that screen capture "was disabled by default." Investigation showed the opposite: screen capture (`screenAnalysisEnabled`) is **already enabled by default** (`AssistantSettings.swift:26`), with SwiftUI mirrors defaulting to `true` and a one-time migration that force-re-enables it. So a "flip the default" change would be a no-op.

The real cause is the **unsolicited macOS permission dialog** on launch:

1. Because screen analysis is enabled by default, the app auto-starts monitoring on every launch (`DesktopHomeView.swift:181-199`), on API-key load (`:249-270`), on app re-activation, on `RewindOnlyView` appear, and after sleep/unlock.
2. Each of those calls `ProactiveAssistantsPlugin.startMonitoring(...)`.
3. When Screen Recording permission isn't granted, `startMonitoring` called `ScreenCaptureService.requestAllScreenCapturePermissions()` → `CGRequestScreenCaptureAccess()`, popping the system dialog — on **every** login until the user grants it.

## Fix

Remove the permission request from `startMonitoring()`'s permission-missing branch (`ProactiveAssistantsPlugin.swift`). The permission is now surfaced **only** by explicit user-initiated enable flows.

This is safe because every user-initiated enable path already handles permission itself **before** reaching `startMonitoring`, so the internal request only ever fired for automatic callers:

| Enable path | Pre-handles permission |
|---|---|
| Menu-bar toggle (`OmiApp.swift:1036`) | gates → opens System Settings |
| Settings toggle (`SettingsPage.swift:6725`) | gates → opens System Settings |
| Sidebar toggle (`SidebarView.swift:1273`) | gates → opens Settings + `requestAllScreenCapturePermissions()` |
| Rewind toggle (`RewindPage.swift:348`) | gates → opens Settings + `requestAllScreenCapturePermissions()` |
| Onboarding | dedicated `OnboardingPermissionStepView` step requests + polls |

The retry loop is retained (now dialog-free) and, together with the existing app-active / auto-restart handlers (`DesktopHomeView.swift:237-247`, `SidebarView.swift:385-406`), starts monitoring automatically once the user grants access out-of-band. Nothing is lost — the app just never prompts unsolicited on login.

## Scope note

`SettingsSyncManager.applyRemoteSettings` (`SettingsSyncManager.swift:52`) can overwrite the local `screenAnalysisEnabled` with a server-stored `false`. That is a **separate** "silently resets on login" vector (it suppresses monitoring rather than popping a dialog) and is intentionally left untouched here to keep the fix minimal and cherry-pickable upstream.

## Changes

- `desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift` — remove the auto-request from the permission-missing branch of `startMonitoring`
- `desktop/CHANGELOG.json` — user-facing changelog entry

## Verification

The app is macOS-only (AppKit/ScreenCaptureKit) and can't be built in this Linux CI env. Suggested manual verification on macOS (per `desktop/CLAUDE.md`, named bundle):

1. `xcrun swift build -c debug --package-path desktop/Desktop`
2. `OMI_APP_NAME="omi-fix-screenperm" ./run.sh`
3. Revoke Screen Recording for the bundle, relaunch → **no** system dialog on launch / API-key load / app re-activation / unlock, while the setting stays enabled.
4. Toggle Screen Capture on from Settings / Sidebar / menu / Rewind → still opens System Settings / requests permission (user-initiated paths unchanged).
5. Grant permission, switch back to the app → monitoring auto-starts with no further prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9FL4EM8GRnZNMRDxNhpT1

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9FL4EM8GRnZNMRDxNhpT1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on macOS where the Screen Recording permission prompt could appear repeatedly on app launch when permission had not yet been granted.
  * Launch and login flows now avoid unnecessary permission dialogs and use the existing permission state before retrying in the background.
* **Documentation**
  * Updated the changelog with the latest app issue note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->