### PR TITLE
fix(desktop): resume screen capture immediately when paywall clears at launch

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed screen capture staying paused for up to a minute after launch when a stale paywall state was restored from a previous session"
+  ],
   "releases": [
     {
       "version": "0.11.423",

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -196,6 +196,7 @@ class AppState: ObservableObject {
       do {
         let metadata = try await APIClient.shared.getTrialMetadata()
         self.trialMetadata = metadata
+        let wasPaywalled = self.isPaywalled
         // Local BYOK always wins — never re-block a user who has all four keys
         // configured, regardless of what the (possibly heartbeat-lagged)
         // backend trial state says.
@@ -205,6 +206,23 @@ class AppState: ObservableObject {
           self.isPaywalled = true
         } else if !metadata.trialExpired && self.isPaywalled {
           self.isPaywalled = false
+        }
+        // If the paywall just lifted — e.g. a stale sticky `desktop_isPaywalled`
+        // flag restored at launch is now cleared by a successful trial fetch —
+        // resume screen-analysis monitoring immediately. Nothing else observes
+        // the flag flip, so without this capture stays paused until a later
+        // incidental startMonitoring trigger (e.g. the next app activation),
+        // which users perceive as capture taking up to ~a minute to turn on.
+        if wasPaywalled && !self.isPaywalled
+          && AssistantSettings.shared.screenAnalysisEnabled
+          && !ProactiveAssistantsPlugin.shared.isMonitoring
+        {
+          log("AppState: paywall lifted — resuming screen analysis monitoring")
+          ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
+            if !success {
+              log("AppState: paywall-lifted monitoring restart failed: \(error ?? "unknown")")
+            }
+          }
         }
       } catch {
         log("AppState: failed to fetch trial metadata: \(error.localizedDescription)")

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -196,7 +196,11 @@ class AppState: ObservableObject {
       do {
         let metadata = try await APIClient.shared.getTrialMetadata()
         self.trialMetadata = metadata
-        let wasPaywalled = self.isPaywalled
+        // Snapshot the paywall state as observed AFTER the network await resolves
+        // (intentionally not before): if two trial fetches are in flight, whichever
+        // resolves first clears the flag, so the second sees this as false and the
+        // restart hook below fires exactly once instead of double-starting.
+        let paywallWasSetBeforeFetch = self.isPaywalled
         // Local BYOK always wins — never re-block a user who has all four keys
         // configured, regardless of what the (possibly heartbeat-lagged)
         // backend trial state says.
@@ -213,9 +217,13 @@ class AppState: ObservableObject {
         // the flag flip, so without this capture stays paused until a later
         // incidental startMonitoring trigger (e.g. the next app activation),
         // which users perceive as capture taking up to ~a minute to turn on.
-        if wasPaywalled && !self.isPaywalled
+        // Gate on keysAvailable so we never start before the app has the config
+        // it needs (mirrors DesktopHomeView's launch gate); the key-load path
+        // retries otherwise.
+        if paywallWasSetBeforeFetch && !self.isPaywalled
           && AssistantSettings.shared.screenAnalysisEnabled
           && !ProactiveAssistantsPlugin.shared.isMonitoring
+          && APIKeyService.keysAvailable
         {
           log("AppState: paywall lifted — resuming screen analysis monitoring")
           ProactiveAssistantsPlugin.shared.startMonitoring { success, error in

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -249,6 +249,12 @@ struct DesktopHomeView: View {
             .onChange(of: apiKeyService.isLoaded) { loaded in
               guard loaded else { return }
               log("DesktopHomeView: API keys loaded — retrying deferred services")
+              // Backend is now reachable (key fetch succeeded). Force a trial
+              // metadata refresh so a stale sticky `desktop_isPaywalled` flag
+              // restored at launch is cleared promptly instead of waiting for
+              // the 60s poll. fetchTrialMetadata() resumes screen-analysis
+              // monitoring itself once the paywall clears.
+              appState.fetchTrialMetadata()
               // Retry transcription
               if AssistantSettings.shared.transcriptionEnabled && !appState.isTranscribing {
                 log("DesktopHomeView: Starting deferred transcription")

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -249,20 +249,28 @@ struct DesktopHomeView: View {
             .onChange(of: apiKeyService.isLoaded) { loaded in
               guard loaded else { return }
               log("DesktopHomeView: API keys loaded — retrying deferred services")
-              // Backend is now reachable (key fetch succeeded). Force a trial
-              // metadata refresh so a stale sticky `desktop_isPaywalled` flag
-              // restored at launch is cleared promptly instead of waiting for
-              // the 60s poll. fetchTrialMetadata() resumes screen-analysis
-              // monitoring itself once the paywall clears.
-              appState.fetchTrialMetadata()
+              // If a (possibly stale) paywall flag was restored at launch, force a
+              // trial-metadata refresh now that the backend is reachable so it
+              // clears in seconds instead of on the next 60s poll. Its paywall-lift
+              // hook resumes screen-analysis monitoring once the flag clears. Only
+              // fetch when actually paywalled — otherwise the launch-time refresh
+              // already covered it and this would be a redundant API call.
+              if AppState.isPaywalledEffective {
+                appState.fetchTrialMetadata()
+              }
               // Retry transcription
               if AssistantSettings.shared.transcriptionEnabled && !appState.isTranscribing {
                 log("DesktopHomeView: Starting deferred transcription")
                 appState.startTranscription()
               }
-              // Retry screen analysis
+              // Retry screen analysis — but not while paywalled: startMonitoring
+              // would hard-stop and post a spurious "trial expired" popup. When a
+              // stale flag is set, the fetchTrialMetadata() above clears it and its
+              // paywall-lift hook restarts monitoring instead.
               let plugin = ProactiveAssistantsPlugin.shared
-              if AssistantSettings.shared.screenAnalysisEnabled && !plugin.isMonitoring {
+              if AssistantSettings.shared.screenAnalysisEnabled && !plugin.isMonitoring
+                && !AppState.isPaywalledEffective
+              {
                 plugin.startMonitoring { success, error in
                   if success {
                     log("DesktopHomeView: Screen analysis started (after key load)")

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -179,7 +179,14 @@ struct DesktopHomeView: View {
               // Start proactive assistants monitoring if enabled in settings.
               // If API keys aren't loaded yet, this may fail — onChange below retries.
               if settings.screenAnalysisEnabled {
-                if APIKeyService.keysAvailable {
+                if AppState.isPaywalledEffective {
+                  // A (possibly stale) paywall flag is set. Don't call
+                  // startMonitoring — it would hard-stop and post a "trial expired"
+                  // popup, which is spurious for a paid user whose sticky flag was
+                  // restored from a prior session. The trial refresh + paywall-lift
+                  // hook starts monitoring once the flag is confirmed clear.
+                  log("DesktopHomeView: Deferring screen analysis — paywalled at launch")
+                } else if APIKeyService.keysAvailable {
                   ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
                     if success {
                       log("DesktopHomeView: Screen analysis started")


### PR DESCRIPTION
## Problem

On the home screen, the "Capture" pill stays OFF/"paused" for up to ~60 seconds after launch and then turns on by itself — even for a signed-in, paid/active (non-BYOK) user who has already granted Screen Recording permission.

Root cause (traced end-to-end):

- The pill reflects live monitoring state (`ProactiveAssistantsPlugin.isMonitoring`), which only becomes true after a successful `startMonitoring()`.
- `startMonitoring()` has a **paywall hard-stop**: `if !isByokActive && desktop_isPaywalled { return "trial_expired" }` (`ProactiveAssistantsPlugin.swift:246-255`).
- `desktop_isPaywalled` is **sticky** — set `true` on a `freemium_threshold_reached` event ("sticky until next app launch or successful reactivation", `AppState.swift:2693-2704`) and **restored from `UserDefaults` at launch** (`AppState.swift:382-383`). A transient/heartbeat-lagged trial event in a prior session leaves it `true` on the next launch.
- Every launch-time `startMonitoring` attempt is refused by that guard. The only thing that clears the flag is `fetchTrialMetadata()` returning `trialExpired=false` (`AppState.swift:204-207`), and its retry cadence is a **60-second** timer (`AppState.swift:265-270`).
- **Nothing observed the flag clearing to restart monitoring** (the only reactors to `isPaywalled` are banner UI + Settings), so capture only resumed on a later incidental `startMonitoring` trigger (e.g. the next app activation) — landing around the 60s mark.

## Fix

1. **`AppState.fetchTrialMetadata()`** — when the paywall transitions from set → clear, immediately resume monitoring if `screenAnalysisEnabled && !isMonitoring`. This is the restart-on-clear hook that was missing.
2. **`DesktopHomeView`** — on API-key load (`.onChange(of: apiKeyService.isLoaded)`, backend now confirmed reachable), force a `fetchTrialMetadata()` so a stale flag clears within seconds instead of waiting for the 60s poll tick.

Together, capture resumes within a few seconds of launch (as soon as the backend is reachable and the trial state is confirmed) instead of after ~a minute.

**Does not weaken paywall enforcement:** a genuinely trial-expired, non-BYOK user's fetch keeps `desktop_isPaywalled = true`, so the restart hook's `!isPaywalled` condition is false and monitoring stays stopped.

## Changes
- `desktop/Desktop/Sources/AppState.swift` — restart-on-clear hook in `fetchTrialMetadata()`
- `desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift` — trial re-fetch on API-key load
- `desktop/CHANGELOG.json` — user-facing entry

## Relationship to #32
Separate, independent bug. #32 stops the macOS Screen Recording **permission dialog** from re-appearing on every login (permission path). This PR addresses the **paywall-gated startup delay** for users who already have permission. Branched off `main` so it carries none of #32's commits.

## Verification

macOS-only (AppKit/ScreenCaptureKit); can't build in this Linux env. Suggested manual verification (per `desktop/CLAUDE.md`, named bundle):

1. `xcrun swift build -c debug --package-path desktop/Desktop`
2. Simulate the stale state: with a paid/active account, set `desktop_isPaywalled = true` in the bundle's UserDefaults (or trigger a freemium event once), then relaunch.
3. Before the fix: the "Capture" pill stays off ~60s. After: it turns on within a few seconds of launch, once keys load and the trial fetch confirms the account is active.
4. Confirm a genuinely expired/free account still shows capture stopped (paywall still enforced).
5. Check the log for `AppState: paywall lifted — resuming screen analysis monitoring`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9FL4EM8GRnZNMRDxNhpT1

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9FL4EM8GRnZNMRDxNhpT1)_