### PR TITLE
fix(desktop): show chat thinking indicator instantly on send

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Chat now shows the thinking indicator instantly when you send a message instead of after a delay on the first message"
+  ],
   "releases": [
     {
       "version": "0.11.423",

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -2490,9 +2490,20 @@ A screenshot may be attached — use it silently only if relevant. Never mention
                 // Sleep was cancelled — don't fire the watchdog.
                 return
             }
-            await MainActor.run {
-                guard let self = self, self.isSending, self.sendGeneration == sendGen else { return }
+            guard let self = self else { return }
+            // Only fire if this exact send is still in flight.
+            let stillStuck = await MainActor.run { () -> Bool in
+                guard self.isSending, self.sendGeneration == sendGen else { return false }
                 log("ChatProvider: send watchdog fired at 180s — bridge is stuck; force-resetting")
+                return true
+            }
+            guard stillStuck else { return }
+            // Interrupt the stuck bridge query before releasing the lock so its
+            // still-live message continuation can't be handed to the next send —
+            // mirrors stopAgent().
+            await self.agentBridge.interrupt()
+            await MainActor.run {
+                guard self.isSending, self.sendGeneration == sendGen else { return }
                 self.isSending = false
                 self.isStopping = false
                 self.errorMessage = "Response took too long. Try again."
@@ -2503,7 +2514,15 @@ A screenshot may be attached — use it silently only if relevant. Never mention
         guard await ensureBridgeStarted() else {
             isSending = false
             isStopping = false
-            errorMessage = "AI not available"
+            // Preserve the descriptive errorMessage set inside ensureBridgeStarted().
+            if errorMessage == nil { errorMessage = "AI not available" }
+            return
+        }
+        // The Stop button is visible during the cold start above. If the user tapped
+        // it, stopAgent() bumped sendGeneration — abort before starting the query.
+        guard sendGeneration == sendGen else {
+            isSending = false
+            isStopping = false
             return
         }
 
@@ -2529,6 +2548,12 @@ A screenshot may be attached — use it silently only if relevant. Never mention
             }
             sessionId = sid
         }
+        // Abort if the user tapped Stop while a new session was being created.
+        guard sendGeneration == sendGen else {
+            isSending = false
+            isStopping = false
+            return
+        }
 
         // Wait for staged attachments to finish uploading so we can include their
         // server IDs in the saved-message metadata. The bubble shows immediately
@@ -2545,6 +2570,12 @@ A screenshot may be attached — use it silently only if relevant. Never mention
             }
             attachmentsForMessage = pendingAttachments
             pendingAttachments.removeAll()
+        }
+        // Abort if the user tapped Stop while attachments were uploading.
+        guard sendGeneration == sendGen else {
+            isSending = false
+            isStopping = false
+            return
         }
         let attachmentMetadataJSON = attachmentsForMessage.isEmpty
             ? nil

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -2469,6 +2469,9 @@ A screenshot may be attached — use it silently only if relevant. Never mention
         // "already sending" guard above reject those double-submits. Each early
         // return below resets isSending so a failed send doesn't wedge the input.
         isSending = true
+        // Clear any stale stopping state from a previously interrupted send so the
+        // input controls aren't left disabled / showing a stopping indicator.
+        isStopping = false
         errorMessage = nil
         sendGeneration += 1
         let sendGen = sendGeneration
@@ -2481,7 +2484,12 @@ A screenshot may be attached — use it silently only if relevant. Never mention
         // by the "already sending" guard. The generation check means the
         // watchdog only fires if no later send has replaced this one.
         Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 180_000_000_000)
+            do {
+                try await Task.sleep(nanoseconds: 180_000_000_000)
+            } catch {
+                // Sleep was cancelled — don't fire the watchdog.
+                return
+            }
             await MainActor.run {
                 guard let self = self, self.isSending, self.sendGeneration == sendGen else { return }
                 log("ChatProvider: send watchdog fired at 180s — bridge is stuck; force-resetting")
@@ -2494,6 +2502,7 @@ A screenshot may be attached — use it silently only if relevant. Never mention
         // Ensure bridge is running
         guard await ensureBridgeStarted() else {
             isSending = false
+            isStopping = false
             errorMessage = "AI not available"
             return
         }
@@ -2514,6 +2523,7 @@ A screenshot may be attached — use it silently only if relevant. Never mention
             }
             guard let sid = currentSessionId else {
                 isSending = false
+                isStopping = false
                 errorMessage = "Failed to create chat session"
                 return
             }
@@ -2529,6 +2539,7 @@ A screenshot may be attached — use it silently only if relevant. Never mention
             let ok = await awaitPendingUploads()
             if !ok {
                 isSending = false
+                isStopping = false
                 errorMessage = "Some attachments failed to upload. Remove them and try again."
                 return
             }

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -2460,33 +2460,14 @@ A screenshot may be attached — use it silently only if relevant. Never mention
             usageLimiter.recordQuery()
         }
 
-        // Ensure bridge is running
-        guard await ensureBridgeStarted() else {
-            errorMessage = "AI not available"
-            return
-        }
-
-        // Show upgrade prompt if over threshold but don't block the message
-        if bridgeMode != BridgeMode.userClaude.rawValue && omiAICumulativeCostUsd >= 50.0 {
-            showOmiThresholdAlert = true
-        }
-
-        // Determine session ID based on mode
-        // In default chat mode (isInDefaultChat=true): no session ID (compatible with Flutter)
-        // In session mode: require session ID
-        var sessionId: String? = nil
-        if !isInDefaultChat {
-            // Session mode - require a session
-            if currentSession == nil {
-                _ = await createNewSession()
-            }
-            guard let sid = currentSessionId else {
-                errorMessage = "Failed to create chat session"
-                return
-            }
-            sessionId = sid
-        }
-
+        // Flip the sending state ON immediately — before the potentially multi-
+        // second ensureBridgeStarted() cold start below — so the "thinking"
+        // shimmer / typing indicator (gated on isSending) appears the instant the
+        // user submits. Previously isSending was only set after the bridge was
+        // ready, so on the first message users saw no feedback and resubmitted,
+        // thinking the message was dropped. Setting it here also makes the
+        // "already sending" guard above reject those double-submits. Each early
+        // return below resets isSending so a failed send doesn't wedge the input.
         isSending = true
         errorMessage = nil
         sendGeneration += 1
@@ -2508,6 +2489,35 @@ A screenshot may be attached — use it silently only if relevant. Never mention
                 self.isStopping = false
                 self.errorMessage = "Response took too long. Try again."
             }
+        }
+
+        // Ensure bridge is running
+        guard await ensureBridgeStarted() else {
+            isSending = false
+            errorMessage = "AI not available"
+            return
+        }
+
+        // Show upgrade prompt if over threshold but don't block the message
+        if bridgeMode != BridgeMode.userClaude.rawValue && omiAICumulativeCostUsd >= 50.0 {
+            showOmiThresholdAlert = true
+        }
+
+        // Determine session ID based on mode
+        // In default chat mode (isInDefaultChat=true): no session ID (compatible with Flutter)
+        // In session mode: require session ID
+        var sessionId: String? = nil
+        if !isInDefaultChat {
+            // Session mode - require a session
+            if currentSession == nil {
+                _ = await createNewSession()
+            }
+            guard let sid = currentSessionId else {
+                isSending = false
+                errorMessage = "Failed to create chat session"
+                return
+            }
+            sessionId = sid
         }
 
         // Wait for staged attachments to finish uploading so we can include their


### PR DESCRIPTION
## Problem

When sending a chat message (onboarding demo chat and main chat), the "thinking" shimmer / typing indicator appears **seconds late** on the first message, so users get no feedback that their message registered and resubmit — thinking it was dropped. (Reported in a user session: *"while it's loading they don't have the shimmer effect, it starts a little after… if it starts shimmering earlier then I know it's running."*)

Root cause: the indicator is gated on `ChatProvider.isSending`, but `isSending` was only set to `true` **after** `await ensureBridgeStarted()` (`ChatProvider.swift`). On a cold bridge that call takes several seconds (waits for API keys, loads context, spawns the ACP subprocess, warms sessions), leaving the UI blank the whole time. The floating bar already flips its loading state synchronously on submit; the onboarding/main chat path did not.

## Fix

Hoist the `isSending = true` flip (plus the send watchdog) **above** `ensureBridgeStarted()` so the shimmer/typing indicator (`OnboardingChatView.swift:236`, gated on `isSending`) and the input spinner appear the instant the user submits.

- Also makes the existing `guard !isSending` reject double-submits during the cold-start window — directly preventing the resubmit behavior.
- Each early-return guard (`ensureBridgeStarted` fail, session-create fail, attachment-upload fail) now resets `isSending` so a failed send never wedges the input.

**Deliberately minimal — message-append/session ordering is unchanged.** I did *not* move the user-bubble / AI-placeholder appends earlier, because `createNewSession()` does `messages = []` (`ChatProvider.swift:1155`); appending optimistic bubbles before session creation would wipe them and break streaming. Flipping `isSending` is what the indicator actually keys off, so it's the correct and safe lever.

## Changes
- `desktop/Desktop/Sources/Providers/ChatProvider.swift` — hoist `isSending`/watchdog above the bridge cold start; reset `isSending` on early returns.
- `desktop/CHANGELOG.json` — user-facing entry.

## Verification

macOS-only; not built in this Linux env. Suggested manual verification (per `desktop/CLAUDE.md`, named bundle):

1. `xcrun swift build -c debug --package-path desktop/Desktop`
2. Force a cold bridge (fresh launch / first message in onboarding). **Before:** several-second blank gap after send. **After:** typing indicator appears immediately on submit.
3. Confirm double-tapping send during the cold start no longer double-submits (second tap is ignored).
4. Error paths still behave: with the bridge unavailable, the indicator clears and an error shows (input not stuck); same for a failed attachment upload.
5. Normal multi-message chat and follow-ups still stream correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9FL4EM8GRnZNMRDxNhpT1

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9FL4EM8GRnZNMRDxNhpT1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The chat “thinking” indicator now appears immediately when you send the first message.

* **Bug Fixes**
  * Improved send-state handling so chat actions recover more reliably if startup or session setup fails.
  * Added a safeguard to clear stuck sending states and show an error if a send does not complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->