### PR TITLE
fix(desktop): surface failures for onboarding data sources

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Onboarding data sources now show a scanning status and a clear notice when Calendar, Email, or Apple Notes can't be read, instead of silently showing 0 items"
+  ],
   "releases": [
     {
       "version": "0.11.423",

--- a/desktop/Desktop/Sources/OnboardingDataSourcesStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingDataSourcesStepView.swift
@@ -121,7 +121,10 @@ struct OnboardingDataSourcesStepView: View {
         ),
         isOn: true,
         isDisabled: coordinator.appleNotesInsightCount > 0,
-        scanFinished: coordinator.appleNotesInsightsFinished,
+        // Reflects both the background scan and a manual folder-select retry;
+        // appleNotesInsightsFinished stays true across a manual re-sync, so use
+        // the in-flight sync flag instead.
+        scanFinished: !coordinator.isSyncingAppleNotes,
         scanFailed: coordinator.appleNotesInsightsFailed,
         actionTitle: coordinator.appleNotesInsightCount > 0 ? nil : "Select Folder",
         action: coordinator.appleNotesInsightCount > 0

--- a/desktop/Desktop/Sources/OnboardingDataSourcesStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingDataSourcesStepView.swift
@@ -73,8 +73,10 @@ struct OnboardingDataSourcesStepView: View {
           sourcePlural: "events",
           memoryCount: coordinator.calendarMemoriesSaved
         ),
-        isOn: true,
-        isDisabled: true
+        isOn: !coordinator.calendarInsightsFailed,
+        isDisabled: true,
+        scanFinished: coordinator.calendarInsightsFinished,
+        scanFailed: coordinator.calendarInsightsFailed
       )
       listDivider
 
@@ -87,8 +89,10 @@ struct OnboardingDataSourcesStepView: View {
           sourcePlural: "emails",
           memoryCount: coordinator.gmailMemoriesSaved
         ),
-        isOn: true,
-        isDisabled: true
+        isOn: !coordinator.gmailInsightsFailed,
+        isDisabled: true,
+        scanFinished: coordinator.gmailInsightsFinished,
+        scanFailed: coordinator.gmailInsightsFailed
       )
       listDivider
 
@@ -117,6 +121,8 @@ struct OnboardingDataSourcesStepView: View {
         ),
         isOn: true,
         isDisabled: coordinator.appleNotesInsightCount > 0,
+        scanFinished: coordinator.appleNotesInsightsFinished,
+        scanFailed: coordinator.appleNotesInsightsFailed,
         actionTitle: coordinator.appleNotesInsightCount > 0 ? nil : "Select Folder",
         action: coordinator.appleNotesInsightCount > 0
           ? nil
@@ -262,11 +268,30 @@ struct OnboardingDataSourcesStepView: View {
     metrics: String,
     isOn: Bool,
     isDisabled: Bool,
+    scanFinished: Bool? = nil,
+    scanFailed: Bool = false,
     actionTitle: String? = nil,
     action: (() -> Void)? = nil,
     onToggle: ((Bool) -> Void)? = nil
   ) -> some View {
-    HStack(alignment: .center, spacing: 12) {
+    // When scan state is supplied, surface the live status ("Scanning…" while a
+    // background read is in flight, a failure notice if it threw) instead of a
+    // bare "0 items" line — so a failed source is no longer indistinguishable
+    // from an empty one.
+    let displayMetrics: String
+    let metricsIsError: Bool
+    if scanFailed {
+      displayMetrics = "Couldn't read — check its permission or connection"
+      metricsIsError = true
+    } else if scanFinished == false {
+      displayMetrics = "Scanning…"
+      metricsIsError = false
+    } else {
+      displayMetrics = metrics
+      metricsIsError = false
+    }
+
+    return HStack(alignment: .center, spacing: 12) {
       ConnectorBrandIcon(brand: brand, size: 38, cornerRadius: 11)
 
       VStack(alignment: .leading, spacing: 3) {
@@ -274,9 +299,9 @@ struct OnboardingDataSourcesStepView: View {
           .font(.system(size: 15, weight: .semibold))
           .foregroundColor(OmiColors.textPrimary)
 
-        Text(metrics)
+        Text(displayMetrics)
           .font(.system(size: 12, weight: .medium))
-          .foregroundColor(OmiColors.textTertiary)
+          .foregroundColor(metricsIsError ? OmiColors.warning : OmiColors.textTertiary)
           .monospacedDigit()
           .lineLimit(1)
       }

--- a/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
@@ -76,9 +76,15 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
   @Published var isSyncingAppleNotes = false
 
   private var insightsStarted = false
-  private var gmailInsightsFinished = false
-  private var calendarInsightsFinished = false
-  private var appleNotesInsightsFinished = false
+  @Published private(set) var gmailInsightsFinished = false
+  @Published private(set) var calendarInsightsFinished = false
+  @Published private(set) var appleNotesInsightsFinished = false
+  // Set when a source's background read throws, so the UI can distinguish a
+  // genuine "0 items" result from a failed connection/permission (previously
+  // both looked identical — the source appeared connected with 0 items).
+  @Published private(set) var gmailInsightsFailed = false
+  @Published private(set) var calendarInsightsFailed = false
+  @Published private(set) var appleNotesInsightsFailed = false
   private var gmailTask: Task<Void, Never>?
   private var calendarTask: Task<Void, Never>?
   private var appleNotesTask: Task<Void, Never>?
@@ -265,6 +271,8 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
 
   func refreshAppleNotesInsights() async {
     lastActionError = nil
+    // A manual folder-select retry clears any earlier background-scan failure.
+    appleNotesInsightsFailed = false
     isSyncingAppleNotes = true
     defer { isSyncingAppleNotes = false }
 
@@ -303,6 +311,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
       }
     } catch {
       lastActionError = error.localizedDescription
+      appleNotesInsightsFailed = true
     }
   }
 
@@ -647,6 +656,9 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
     gmailInsightsFinished = false
     calendarInsightsFinished = false
     appleNotesInsightsFinished = false
+    gmailInsightsFailed = false
+    calendarInsightsFailed = false
+    appleNotesInsightsFailed = false
     webResearchSummary = ""
 
     gmailTask = Task {
@@ -701,6 +713,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
         log(
           "OnboardingPagedIntroCoordinator: Gmail insights unavailable: \(error.localizedDescription)"
         )
+        await MainActor.run { self.gmailInsightsFailed = true }
         await self.markInsightFinished(.gmail)
       }
     }
@@ -764,6 +777,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
         log(
           "OnboardingPagedIntroCoordinator: Calendar insights unavailable: \(error.localizedDescription)"
         )
+        await MainActor.run { self.calendarInsightsFailed = true }
         await self.markInsightFinished(.calendar)
       }
     }
@@ -835,6 +849,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
           self.appleNotesInsightCount = 0
           self.appleNotesSummary = ""
           self.appleNotesMemoriesSaved = 0
+          self.appleNotesInsightsFailed = true
         }
         await self.markInsightFinished(.appleNotes)
       }


### PR DESCRIPTION
## Problem

In the onboarding **"Your 2nd brain is live"** step (`OnboardingDataSourcesStepView`), the Calendar, Email, and Apple Notes rows are populated by background scans in `OnboardingPagedIntroCoordinator.startBackgroundInsightsIfNeeded()`. When a source's read **threw** — no connection, missing permission, API error — the `catch` block only called `log(...)`; it set no error state. So the row kept showing `0 events • 0 memories` with its toggle **on**, visually identical to a genuine "found nothing" result, and the **Continue** button appeared as if every source connected fine. Users had no way to tell a failed source from an empty one.

## Fix

Track per-source scan state on the coordinator and surface it in the row:

**`OnboardingPagedIntroCoordinator.swift`**
- Promote the existing `gmail/calendar/appleNotesInsightsFinished` flags to `@Published private(set)` and add matching `…InsightsFailed` flags.
- Reset the failed flags when a scan run starts; set the relevant flag in each source's `catch` (Gmail, Calendar, Apple Notes background task) and in the manual `refreshAppleNotesInsights()` failure path.
- A manual Apple Notes folder-select retry clears the failure flag on entry.

**`OnboardingDataSourcesStepView.swift`**
- `compactSourceRow` takes optional `scanFinished` / `scanFailed`. It renders `"Scanning…"` while a read is in flight, and a warning-colored `"Couldn't read — check its permission or connection"` on failure, instead of the bare metrics line. Calendar/Email flip their toggle off when failed.

Continue is still gated on `isResearchComplete` as before — this only adds visibility; it never blocks the user.

## Changes
- `desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift`
- `desktop/Desktop/Sources/OnboardingDataSourcesStepView.swift`
- `desktop/CHANGELOG.json`

## Verification

macOS-only; not built in this Linux env. Suggested manual verification (per `desktop/CLAUDE.md`, named bundle):

1. `xcrun swift build -c debug --package-path desktop/Desktop`
2. Run onboarding to the data-sources step **without** Calendar/Gmail connected (or with the reader services failing). **Before:** rows show `0 events • 0 memories`, toggles on. **After:** rows show `"Couldn't read — check its permission or connection"` in warning color, toggles off; while scanning they show `"Scanning…"`.
3. With sources connected and populated, confirm rows still show real counts and Continue behaves as before.
4. Apple Notes: trigger a failed background scan, then use **Select Folder** → confirm the failure notice clears and counts appear on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9FL4EM8GRnZNMRDxNhpT1

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9FL4EM8GRnZNMRDxNhpT1)_